### PR TITLE
clang-format fixes

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,545 +1,470 @@
 #include "ast.hpp"
+
 #include "parser.hpp"
+
 #include <sstream>
 
 using namespace std;
 
-AST::AST(string input) { this->parser = unique_ptr<Parser> (new Parser(input)); }
+AST::AST(string input) { this->parser = unique_ptr<Parser>(new Parser(input)); }
 
 Statement::Statement() { this->nodetype = statement; }
 Expression::Expression() { this->nodetype = expression; }
 
-
 ArrayLiteral::ArrayLiteral() {
-  this->nodetype = expression;
-  this->type = arrayLiteral;
+    this->nodetype = expression;
+    this->type = arrayLiteral;
 }
-
 
 AssignmentExpressionStatement::AssignmentExpressionStatement() {
-  this->name = nullptr;
-  this->value = nullptr;
-  this->type = assignmentExpressionStatement;
-  this->nodetype = statement;
+    this->name = nullptr;
+    this->value = nullptr;
+    this->type = assignmentExpressionStatement;
+    this->nodetype = statement;
 }
-
 
 BlockStatement::BlockStatement() {
-  this->type = blockStatement;
-  this->nodetype = statement;
+    this->type = blockStatement;
+    this->nodetype = statement;
 }
-
 
 BooleanLiteral::BooleanLiteral() {
-  this->type = booleanExpression;
-  this->nodetype = expression;
+    this->type = booleanExpression;
+    this->nodetype = expression;
 }
-
 
 CallExpression::CallExpression() {
-  this->nodetype = expression;
-  this->type = callExpression;
-  this->_function = nullptr;
+    this->nodetype = expression;
+    this->type = callExpression;
+    this->_function = nullptr;
 }
-
 
 DoExpression::DoExpression() {
-  this->nodetype = expression;
-  this->type = doExpression;
-  this->body = nullptr;
-  this->condition = nullptr;
+    this->nodetype = expression;
+    this->type = doExpression;
+    this->body = nullptr;
+    this->condition = nullptr;
 }
-
 
 ExpressionStatement::ExpressionStatement() {
-  this->nodetype = statement;
-  this->type = expressionStatement;
-  this->expression = nullptr;
+    this->nodetype = statement;
+    this->type = expressionStatement;
+    this->expression = nullptr;
 }
-
 
 ForExpression::ForExpression() {
-  this->nodetype = expression;
-  this->type = forExpression;
-  this->body = nullptr;
+    this->nodetype = expression;
+    this->type = forExpression;
+    this->body = nullptr;
 }
-
 
 FloatLiteral::FloatLiteral() {
-  this->type = floatLiteral;
-  this->nodetype = expression;
+    this->type = floatLiteral;
+    this->nodetype = expression;
 }
-
 
 FunctionLiteral::FunctionLiteral() {
-  this->type = functionLiteral;
-  this->nodetype = expression;
-  this->name = nullptr;
-  this->body = nullptr;
+    this->type = functionLiteral;
+    this->nodetype = expression;
+    this->name = nullptr;
+    this->body = nullptr;
 }
-
 
 FunctionStatement::FunctionStatement() {
-  this->type = functionStatement;
-  this->nodetype = expression;
-  this->name = nullptr;
-  this->body = nullptr;
+    this->type = functionStatement;
+    this->nodetype = expression;
+    this->name = nullptr;
+    this->body = nullptr;
 }
-
 
 HashLiteral::HashLiteral() {
-  this->nodetype = expression;
-  this->type = hashLiteral;
+    this->nodetype = expression;
+    this->type = hashLiteral;
 }
-
 
 IfExpression::IfExpression() {
-  this->type = ifExpression;
-  this->nodetype = expression;
-  this->condition = nullptr;
-  this->consequence = nullptr;
-  this->alternative = nullptr;
+    this->type = ifExpression;
+    this->nodetype = expression;
+    this->condition = nullptr;
+    this->consequence = nullptr;
+    this->alternative = nullptr;
 }
-
 
 IdentifierLiteral::IdentifierLiteral() {
-  this->nodetype = expression;
-  this->type = identifier;
+    this->nodetype = expression;
+    this->type = identifier;
 }
-
 
 IdentifierStatement::IdentifierStatement() {
-  this->name = nullptr;
-  this->value = nullptr;
-  this->type = identifierStatement;
-  this->nodetype = statement;
+    this->name = nullptr;
+    this->value = nullptr;
+    this->type = identifierStatement;
+    this->nodetype = statement;
 }
 
-
 IndexExpression::IndexExpression() {
-  this->nodetype = expression;
-  this->type = indexExpression;
-  this->_left = nullptr;
-  this->index = nullptr;
+    this->nodetype = expression;
+    this->type = indexExpression;
+    this->_left = nullptr;
+    this->index = nullptr;
 }
 
 InfixExpression::InfixExpression() {
-  this->_left = nullptr;
-  this->_right = nullptr;
-  this->type = infixExpression;
-  this->nodetype = expression;
+    this->_left = nullptr;
+    this->_right = nullptr;
+    this->type = infixExpression;
+    this->nodetype = expression;
 }
-
 
 IntegerLiteral::IntegerLiteral() {
-  this->type = integerLiteral;
-  this->nodetype = expression;
+    this->type = integerLiteral;
+    this->nodetype = expression;
 }
-
 
 LetStatement::LetStatement() {
-  this->name = nullptr;
-  this->value = nullptr;
-  this->type = letStatement;
-  this->nodetype = statement;
+    this->name = nullptr;
+    this->value = nullptr;
+    this->type = letStatement;
+    this->nodetype = statement;
 }
 
-
 PostfixExpression::PostfixExpression() {
-  this->_left = nullptr;
-  this->type = postfixExpression;
-  this->nodetype = expression;
+    this->_left = nullptr;
+    this->type = postfixExpression;
+    this->nodetype = expression;
 }
 
 PrefixExpression::PrefixExpression() {
-  this->_right = nullptr;
-  this->type = prefixExpression;
-  this->nodetype = expression;
+    this->_right = nullptr;
+    this->type = prefixExpression;
+    this->nodetype = expression;
 }
 
-
 ReturnStatement::ReturnStatement() {
-  this->returnValue = nullptr;
-  this->type = returnStatement;
-  this->nodetype = statement;
+    this->returnValue = nullptr;
+    this->type = returnStatement;
+    this->nodetype = statement;
 }
 
 StringLiteral::StringLiteral() {
-  this->type = stringLiteral;
-  this->nodetype = expression;
+    this->type = stringLiteral;
+    this->nodetype = expression;
 }
 
 WhileExpression::WhileExpression() {
-  this->nodetype = expression;
-  this->type = whileExpression;
-  this->condition = nullptr;
-  this->body = nullptr;
+    this->nodetype = expression;
+    this->type = whileExpression;
+    this->condition = nullptr;
+    this->body = nullptr;
 }
-
 
 void AST::checkParserErrors() {
-  int len = this->parser->errors.size();
-  if (len == 0)
-    return;
+    int len = this->parser->errors.size();
+    if (len == 0) return;
 }
-
 
 void AST::parseProgram() {
-  while (this->parser->currentToken.type != TokenType._EOF) {
-    shared_ptr<Statement> stmt = this->parser->parseStatement();
+    while (this->parser->currentToken.type != TokenType._EOF) {
+        shared_ptr<Statement> stmt = this->parser->parseStatement();
 
-    if (stmt != nullptr) {
-      this->Statements.push_back(stmt);
+        if (stmt != nullptr) {
+            this->Statements.push_back(stmt);
+        }
+
+        this->parser->nextToken();
     }
 
-    this->parser->nextToken();
-  }
-
-  this->checkParserErrors();
+    this->checkParserErrors();
 }
-
 
 void Statement::setDataType(string lit) {
-  if (lit == "int")
-    this->datatype = INT;
-  else if (lit == "float")
-    this->datatype = FLOAT;
-  else if (lit == "bool")
-    this->datatype = BOOLEAN;
-  else if (lit == "string")
-    this->datatype = _STRING;
-  else if (lit == "void")
-    this->datatype = VOID;
+    if (lit == "int") this->datatype = INT;
+    else if (lit == "float") this->datatype = FLOAT;
+    else if (lit == "bool") this->datatype = BOOLEAN;
+    else if (lit == "string") this->datatype = _STRING;
+    else if (lit == "void") this->datatype = VOID;
 }
-
 
 void Expression::setDataType(string lit) {
-  if (lit == "int")
-    this->datatype = INT;
-  else if (lit == "float")
-    this->datatype = FLOAT;
-  else if (lit == "bool")
-    this->datatype = BOOLEAN;
-  else if (lit == "string")
-    this->datatype = _STRING;
-  else if (lit == "void")
-    this->datatype = VOID;
+    if (lit == "int") this->datatype = INT;
+    else if (lit == "float") this->datatype = FLOAT;
+    else if (lit == "bool") this->datatype = BOOLEAN;
+    else if (lit == "string") this->datatype = _STRING;
+    else if (lit == "void") this->datatype = VOID;
 }
-
 
 void Statement::setStatementNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
+    this->token = tok;
+    this->setDataType(tok.literal);
 }
-
 
 void Expression::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
+    this->token = tok;
+    this->setDataType(tok.literal);
 }
-
 
 void IdentifierLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
-  this->value = tok.literal;
+    this->token = tok;
+    this->setDataType(tok.literal);
+    this->value = tok.literal;
 }
-
 
 void PrefixExpression::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
-  this->_operator = tok.literal;
+    this->token = tok;
+    this->setDataType(tok.literal);
+    this->_operator = tok.literal;
 }
-
 
 void InfixExpression::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
-  this->_operator = tok.literal;
+    this->token = tok;
+    this->setDataType(tok.literal);
+    this->_operator = tok.literal;
 }
-
 
 void IntegerLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->datatype = INT;
+    this->token = tok;
+    this->datatype = INT;
 }
-
 
 void PostfixExpression::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->_operator = tok.literal;
-  this->setDataType(tok.literal);
+    this->token = tok;
+    this->_operator = tok.literal;
+    this->setDataType(tok.literal);
 }
-
 
 void StringLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->value = tok.literal;
-  this->datatype = _STRING;
+    this->token = tok;
+    this->value = tok.literal;
+    this->datatype = _STRING;
 }
-
 
 void BooleanLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->datatype = BOOLEAN;
-  if (tok.type == TokenType._TRUE)
-    this->value = true;
-  else if (tok.type == TokenType._FALSE)
-    this->value = false;
+    this->token = tok;
+    this->datatype = BOOLEAN;
+    if (tok.type == TokenType._TRUE) this->value = true;
+    else if (tok.type == TokenType._FALSE) this->value = false;
 }
-
 
 void FloatLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->datatype = FLOAT;
+    this->token = tok;
+    this->datatype = FLOAT;
 }
-
 
 void FunctionLiteral::setExpressionNode(Token tok) {
-  this->token = tok;
-  this->setDataType(tok.literal);
+    this->token = tok;
+    this->setDataType(tok.literal);
 }
-
 
 string Statement::printString() {
-  ostringstream ss;
-  ss << "{ " << this->token.literal << "; }";
-  return ss.str();
+    ostringstream ss;
+    ss << "{ " << this->token.literal << "; }";
+    return ss.str();
 }
-
 
 string Expression::printString() {
-  ostringstream ss;
-  ss << "{ " << this->token.literal << "; }";
-  return ss.str();
+    ostringstream ss;
+    ss << "{ " << this->token.literal << "; }";
+    return ss.str();
 }
-
 
 string IdentifierStatement::printString() {
-  ostringstream ss;
-  ss << DatatypeMap.at(this->datatype);
-  ss << this->token.literal << " ";
-  ss << this->name->printString() << " = ";
+    ostringstream ss;
+    ss << DatatypeMap.at(this->datatype);
+    ss << this->token.literal << " ";
+    ss << this->name->printString() << " = ";
 
-  if (this->value != nullptr)
-    ss << this->value->printString();
-  ss << ";";
+    if (this->value != nullptr) ss << this->value->printString();
+    ss << ";";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string LetStatement::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << this->token.literal << " ";
-  ss << this->name->printString() << " = ";
+    ss << this->token.literal << " ";
+    ss << this->name->printString() << " = ";
 
-  if (this->value != nullptr)
-    ss << this->value->printString();
-  ss << ";";
+    if (this->value != nullptr) ss << this->value->printString();
+    ss << ";";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string ReturnStatement::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << this->token.literal << " ";
+    ss << this->token.literal << " ";
 
-  if (this->returnValue != nullptr)
-    ss << this->returnValue->printString();
-  ss << ";";
+    if (this->returnValue != nullptr) ss << this->returnValue->printString();
+    ss << ";";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string ExpressionStatement::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  if (this->expression != nullptr)
-    ss << this->expression->printString();
+    if (this->expression != nullptr) ss << this->expression->printString();
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string PostfixExpression::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << "(" << this->_operator << this->_left->printString() << ")";
+    ss << "(" << this->_operator << this->_left->printString() << ")";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string PrefixExpression::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << "(" << this->_operator << this->_right->printString() << ")";
+    ss << "(" << this->_operator << this->_right->printString() << ")";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string InfixExpression::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << "(" << this->_left->printString() << " " + this->_operator + " " <<
-    this->_right->printString() << ")";
+    ss << "(" << this->_left->printString() << " " + this->_operator + " "
+       << this->_right->printString() << ")";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string BlockStatement::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  for (int i = 0; i < this->statements.size(); i++)
-    ss << this->statements[i]->printString();
+    for (int i = 0; i < this->statements.size(); i++)
+        ss << this->statements[i]->printString();
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string IfExpression::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  ss << "if" << this->condition->printString() << " " << this->consequence->printString();
+    ss << "if" << this->condition->printString() << " " << this->consequence->printString();
 
-  for (int i = 0; i < this->conditions.size(); i++) {
-    ss << " else if " << this->conditions[i]->printString() << " " <<
-      this->alternatives[i]->printString();
-  }
+    for (int i = 0; i < this->conditions.size(); i++) {
+        ss << " else if " << this->conditions[i]->printString() << " "
+           << this->alternatives[i]->printString();
+    }
 
-  if (this->alternative != nullptr)
-    ss << " else " << this->alternative->printString();
+    if (this->alternative != nullptr) ss << " else " << this->alternative->printString();
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string FunctionStatement::printString() {
-  ostringstream ss;
-  vector<string> params{};
+    ostringstream ss;
+    vector<string> params{};
 
-  for (int i = 0; i < this->parameters.size(); i++)
-    params.push_back(this->parameters[i]->printString());
+    for (int i = 0; i < this->parameters.size(); i++)
+        params.push_back(this->parameters[i]->printString());
 
-  ss << DatatypeMap.at(this->datatype) << " " << 
-    this->name->token.literal << "(";
+    ss << DatatypeMap.at(this->datatype) << " " << this->name->token.literal << "(";
 
-  for (string param : params)
-    ss << param << ", ";
+    for (string param : params)
+        ss << param << ", ";
 
-  ss << ") " << this->body->printString();
-  return ss.str();
+    ss << ") " << this->body->printString();
+    return ss.str();
 }
-
 
 string FunctionLiteral::printString() {
-  ostringstream ss;
-  vector<string> params{};
+    ostringstream ss;
+    vector<string> params{};
 
-  for (int i = 0; i < this->parameters.size(); i++)
-    params.push_back(this->parameters[i]->printString());
+    for (int i = 0; i < this->parameters.size(); i++)
+        params.push_back(this->parameters[i]->printString());
 
-  ss << DatatypeMap.at(this->datatype) << " " << 
-    this->name->token.literal << "(";
+    ss << DatatypeMap.at(this->datatype) << " " << this->name->token.literal << "(";
 
-  for (string param : params)
-    ss << param << ", ";
+    for (string param : params)
+        ss << param << ", ";
 
-  ss << ") " << this->body->printString();
-  return ss.str();
+    ss << ") " << this->body->printString();
+    return ss.str();
 }
-
 
 string CallExpression::printString() {
-  ostringstream ss;
-  vector<string> args{};
+    ostringstream ss;
+    vector<string> args{};
 
-  for (int i = 0; i < this->arguments.size(); i++)
-    args.push_back(this->arguments[i]->printString());
+    for (int i = 0; i < this->arguments.size(); i++)
+        args.push_back(this->arguments[i]->printString());
 
-  ss << this->_function->printString();
-  ss << this->token.literal << "(";
+    ss << this->_function->printString();
+    ss << this->token.literal << "(";
 
-  for (string arg : args)
-    ss << arg << ", ";
+    for (string arg : args)
+        ss << arg << ", ";
 
-  ss << ") ";
-  return ss.str();
+    ss << ") ";
+    return ss.str();
 }
-
 
 string BooleanLiteral::printString() {
-  ostringstream ss;
+    ostringstream ss;
 
-  if (this->value)
-    ss << "( true )";
-  else
-    ss << "( false )";
+    if (this->value) ss << "( true )";
+    else ss << "( false )";
 
-  return ss.str();
+    return ss.str();
 }
-
 
 string ArrayLiteral::printString() {
-  ostringstream ss;
-  vector<string> elements{};
+    ostringstream ss;
+    vector<string> elements{};
 
-  for (int i = 0; i < this->elements.size(); i++)
-    elements.push_back(this->elements[i]->printString());
+    for (int i = 0; i < this->elements.size(); i++)
+        elements.push_back(this->elements[i]->printString());
 
-  ss << "[";
+    ss << "[";
 
-  for (string el : elements)
-    ss << el << ", ";
+    for (string el : elements)
+        ss << el << ", ";
 
-  ss << "] ";
-  return ss.str();
+    ss << "] ";
+    return ss.str();
 }
-
 
 string IndexExpression::printString() {
-  ostringstream ss;
-  ss << "(";
-  ss << this->_left->printString();
-  ss << "[";
-  ss << this->index->printString();
-  ss << "]) ";
-  return ss.str();
+    ostringstream ss;
+    ss << "(";
+    ss << this->_left->printString();
+    ss << "[";
+    ss << this->index->printString();
+    ss << "]) ";
+    return ss.str();
 }
-
 
 string HashLiteral::printString() {
-  ostringstream ss;
-  vector<string> pairs{};
+    ostringstream ss;
+    vector<string> pairs{};
 
+    for (pair<shared_ptr<Expression>, shared_ptr<Expression>> pair : this->pairs) {
+        ostringstream p;
+        p << pair.first->printString() << ":" << pair.second->printString();
+        pairs.push_back(p.str());
+    }
 
-  for (pair<shared_ptr<Expression>, shared_ptr<Expression>> pair : this->pairs) {
-    ostringstream p;
-    p << pair.first->printString() << ":" << pair.second->printString();
-    pairs.push_back(p.str());
-  }
+    ss << "{";
 
-  ss << "{";
+    for (string el : pairs)
+        ss << el << ", ";
 
-  for (string el : pairs)
-    ss << el << ", ";
-
-  ss << "} ";
-  return ss.str();
+    ss << "} ";
+    return ss.str();
 }
 
-
 string AST::printString() {
-  ostringstream ss;
-  for (auto stmt : this->Statements)
-    ss << stmt->printString();
-  return ss.str();
+    ostringstream ss;
+    for (auto stmt : this->Statements)
+        ss << stmt->printString();
+    return ss.str();
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,446 +1,397 @@
 #pragma once
 #include "parser.hpp"
+
 #include <memory>
 
-
-enum NodeType{
-  expression,
-  statement,
+enum NodeType {
+    expression,
+    statement,
 };
 
 enum StatementType {
-  assignmentExpressionStatement,
-  blockStatement,
-  expressionStatement,
-  functionStatement,
-  identifierStatement,
-  letStatement,
-  returnStatement,
+    assignmentExpressionStatement,
+    blockStatement,
+    expressionStatement,
+    functionStatement,
+    identifierStatement,
+    letStatement,
+    returnStatement,
 };
-
 
 enum ExpressionType {
-  arrayLiteral,
-  booleanExpression,
-  callExpression,
-  doExpression,
-  floatLiteral,
-  forExpression,
-  functionLiteral,
-  hashLiteral,
-  identifier,
-  ifExpression,
-  indexExpression,
-  infixExpression,
-  integerLiteral,
-  postfixExpression,
-  prefixExpression,
-  stringLiteral,
-  whileExpression,
+    arrayLiteral,
+    booleanExpression,
+    callExpression,
+    doExpression,
+    floatLiteral,
+    forExpression,
+    functionLiteral,
+    hashLiteral,
+    identifier,
+    ifExpression,
+    indexExpression,
+    infixExpression,
+    integerLiteral,
+    postfixExpression,
+    prefixExpression,
+    stringLiteral,
+    whileExpression,
 };
 
-
 typedef struct AST {
-  std::unique_ptr<Parser> parser;
-  std::vector<std::shared_ptr<Statement>> Statements;
+    std::unique_ptr<Parser> parser;
+    std::vector<std::shared_ptr<Statement>> Statements;
 
-  AST(std::string);
-  ~AST() {this->Statements.clear();};
+    AST(std::string);
+    ~AST() { this->Statements.clear(); };
 
-  void checkParserErrors();
-  void parseProgram();
-  std::string printString();
+    void checkParserErrors();
+    void parseProgram();
+    std::string printString();
 } AST;
 
-
 typedef struct Node {
-  ~Node() = default;
-  int nodetype;
-  int datatype;
-  std::string literal;
+    ~Node() = default;
+    int nodetype;
+    int datatype;
+    std::string literal;
 } Node;
 
-
 typedef struct Statement : Node {
-  Statement();
-  virtual ~Statement() = default; 
+    Statement();
+    virtual ~Statement() = default;
 
-  Token token;
-  StatementType type;
+    Token token;
+    StatementType type;
 
-  virtual void setStatementNode(Token);
-  virtual std::string printString();
-  void setDataType(std::string);
+    virtual void setStatementNode(Token);
+    virtual std::string printString();
+    void setDataType(std::string);
 } Statement;
 
-
 typedef struct Expression : Node {
-  Expression();
-  virtual ~Expression() = default; 
+    Expression();
+    virtual ~Expression() = default;
 
-  Token token;
-  ExpressionType type;
+    Token token;
+    ExpressionType type;
 
-  virtual void setExpressionNode(Token);
-  virtual std::string printString();
-  void setDataType(std::string);
+    virtual void setExpressionNode(Token);
+    virtual std::string printString();
+    void setDataType(std::string);
 } Expression;
 
-
 typedef struct ArrayLiteral : Expression {
-  ArrayLiteral();
-  ~ArrayLiteral() {this->elements.clear();};
+    ArrayLiteral();
+    ~ArrayLiteral() { this->elements.clear(); };
 
-  Token token;
-  std::vector<std::shared_ptr<Expression>> elements;
+    Token token;
+    std::vector<std::shared_ptr<Expression>> elements;
 
-
-  std::string printString();
+    std::string printString();
 } ArrayLiteral;
 
-
 typedef struct AssignmentExpressionStatement : Statement {
-  AssignmentExpressionStatement();
-  ~AssignmentExpressionStatement() = default;
+    AssignmentExpressionStatement();
+    ~AssignmentExpressionStatement() = default;
 
-  Token token;
-  std::shared_ptr<IdentifierLiteral> name;
-  std::string _operator;
-  std::shared_ptr<Expression> value;
+    Token token;
+    std::shared_ptr<IdentifierLiteral> name;
+    std::string _operator;
+    std::shared_ptr<Expression> value;
 
 } AssignmentExpressionStatement;
 
-
 typedef struct BlockStatement : Statement {
-  BlockStatement();
-  ~BlockStatement() {this->statements.clear();};
+    BlockStatement();
+    ~BlockStatement() { this->statements.clear(); };
 
-  Token token;
-  std::vector<std::shared_ptr<Statement>> statements;
+    Token token;
+    std::vector<std::shared_ptr<Statement>> statements;
 
-  std::string printString();
+    std::string printString();
 } BlockStatement;
 
-
 typedef struct BooleanLiteral : Expression {
-  BooleanLiteral();
+    BooleanLiteral();
 
-  Token token;
-  bool value;
+    Token token;
+    bool value;
 
-  void setExpressionNode(Token);
-  std::string printString();
+    void setExpressionNode(Token);
+    std::string printString();
 } BooleanLiteral;
 
+typedef struct CallExpression : Expression {
+    CallExpression();
+    ~CallExpression() { this->arguments.clear(); };
 
-typedef struct CallExpression : Expression { 
-  CallExpression();
-  ~CallExpression() {this->arguments.clear();};
+    Token token;
+    std::shared_ptr<Expression> _function;
+    std::vector<std::shared_ptr<Expression>> arguments;
 
-  Token token;
-  std::shared_ptr<Expression> _function;
-  std::vector<std::shared_ptr<Expression>> arguments;
-
-  std::string printString();
+    std::string printString();
 } CallExpression;
 
-
 typedef struct DoExpression : Expression {
-  DoExpression();
-  ~DoExpression() = default;
+    DoExpression();
+    ~DoExpression() = default;
 
-  Token token;
-  std::shared_ptr<BlockStatement> body;
-  std::shared_ptr<Expression> condition;
+    Token token;
+    std::shared_ptr<BlockStatement> body;
+    std::shared_ptr<Expression> condition;
 
 } DoExpression;
 
-
 typedef struct ExpressionStatement : Statement {
-  ExpressionStatement();
-  ~ExpressionStatement() = default;
+    ExpressionStatement();
+    ~ExpressionStatement() = default;
 
-  Token token;
-  std::shared_ptr<Expression> expression;
+    Token token;
+    std::shared_ptr<Expression> expression;
 
-  std::string printString();
+    std::string printString();
 } ExpressionStatement;
 
-
 typedef struct FloatLiteral : Expression {
-  FloatLiteral();
+    FloatLiteral();
 
-  Token token;
-  float value;
+    Token token;
+    float value;
 
-  void setExpressionNode(Token);
-  inline std::string printString() { return std::to_string(this->value); };
+    void setExpressionNode(Token);
+    inline std::string printString() { return std::to_string(this->value); };
 } FloatLiteral;
 
-
 typedef struct ForExpression : Expression {
-  ForExpression();
-  ~ForExpression() {this->expressions.clear(); this->statements.clear();};
+    ForExpression();
+    ~ForExpression() {
+        this->expressions.clear();
+        this->statements.clear();
+    };
 
-  Token token;
-  std::shared_ptr<Expression> start;
-  std::shared_ptr<Expression> end;
-  std::shared_ptr<Expression> increment;
-  std::vector<std::shared_ptr<Expression>> expressions;
-  std::vector<std::shared_ptr<Statement>> statements;
-  std::shared_ptr<BlockStatement> body;
+    Token token;
+    std::shared_ptr<Expression> start;
+    std::shared_ptr<Expression> end;
+    std::shared_ptr<Expression> increment;
+    std::vector<std::shared_ptr<Expression>> expressions;
+    std::vector<std::shared_ptr<Statement>> statements;
+    std::shared_ptr<BlockStatement> body;
 
 } ForExpression;
 
-
 typedef struct FunctionLiteral : Expression {
-  FunctionLiteral();
-  ~FunctionLiteral() {this->parameters.clear();};
+    FunctionLiteral();
+    ~FunctionLiteral() { this->parameters.clear(); };
 
-  Token token;
-  std::shared_ptr<IdentifierLiteral> name;
-  std::vector<std::shared_ptr<IdentifierLiteral>> parameters;
-  std::shared_ptr<BlockStatement> body;
+    Token token;
+    std::shared_ptr<IdentifierLiteral> name;
+    std::vector<std::shared_ptr<IdentifierLiteral>> parameters;
+    std::shared_ptr<BlockStatement> body;
 
-  std::string printString();
-  void setExpressionNode(Token);
+    std::string printString();
+    void setExpressionNode(Token);
 } FunctionLiteral;
 
-
 typedef struct FunctionStatement : Statement {
-  FunctionStatement();
-  ~FunctionStatement() {this->parameters.clear();};
+    FunctionStatement();
+    ~FunctionStatement() { this->parameters.clear(); };
 
-  Token token;
-  std::shared_ptr<IdentifierLiteral> name;
-  std::vector<std::shared_ptr<IdentifierLiteral>> parameters;
-  std::shared_ptr<BlockStatement> body;
+    Token token;
+    std::shared_ptr<IdentifierLiteral> name;
+    std::vector<std::shared_ptr<IdentifierLiteral>> parameters;
+    std::shared_ptr<BlockStatement> body;
 
-  std::string printString();
+    std::string printString();
 } FunctionStatement;
 
-
 typedef struct HashLiteral : Expression {
-  HashLiteral();
-  ~HashLiteral() {this->pairs.clear();}
+    HashLiteral();
+    ~HashLiteral() { this->pairs.clear(); }
 
-  Token token;
-  std::unordered_map<std::shared_ptr<Expression>, std::shared_ptr<Expression>> pairs;
+    Token token;
+    std::unordered_map<std::shared_ptr<Expression>, std::shared_ptr<Expression>> pairs;
 
-  std::string printString();
+    std::string printString();
 } HashLiteral;
 
-
 typedef struct IfExpression : Expression {
-  IfExpression();
-  ~IfExpression() {this->conditions.clear(); this->alternatives.clear();};
+    IfExpression();
+    ~IfExpression() {
+        this->conditions.clear();
+        this->alternatives.clear();
+    };
 
-  Token token;
-  std::shared_ptr<Expression> condition;
-  std::shared_ptr<BlockStatement> consequence;
-  std::shared_ptr<BlockStatement> alternative;
-  std::vector<std::shared_ptr<Expression>> conditions;
-  std::vector<std::shared_ptr<BlockStatement>> alternatives;
+    Token token;
+    std::shared_ptr<Expression> condition;
+    std::shared_ptr<BlockStatement> consequence;
+    std::shared_ptr<BlockStatement> alternative;
+    std::vector<std::shared_ptr<Expression>> conditions;
+    std::vector<std::shared_ptr<BlockStatement>> alternatives;
 
-  std::string printString();
+    std::string printString();
 } IfExpression;
 
-
 typedef struct IdentifierLiteral : Expression {
-  IdentifierLiteral();
+    IdentifierLiteral();
 
-  Token token;
-  std::string value;
+    Token token;
+    std::string value;
 
-  void setExpressionNode(Token);
-  inline std::string printString() { return this->value; };
+    void setExpressionNode(Token);
+    inline std::string printString() { return this->value; };
 } IdentifierLiteral;
 
-
 typedef struct IdentifierStatement : Statement {
-  IdentifierStatement();
-  ~IdentifierStatement() = default;
+    IdentifierStatement();
+    ~IdentifierStatement() = default;
 
-  Token token;
-  std::shared_ptr<IdentifierLiteral> name;
-  std::shared_ptr<Expression> value;
+    Token token;
+    std::shared_ptr<IdentifierLiteral> name;
+    std::shared_ptr<Expression> value;
 
-  std::string printString();
+    std::string printString();
 } IdentifierStatement;
 
-
 typedef struct IndexExpression : Expression {
-  IndexExpression();
-  ~IndexExpression() = default;
+    IndexExpression();
+    ~IndexExpression() = default;
 
-  Token token;
-  std::shared_ptr<Expression> _left;
-  std::shared_ptr<Expression> index;
+    Token token;
+    std::shared_ptr<Expression> _left;
+    std::shared_ptr<Expression> index;
 
-  std::string printString();
+    std::string printString();
 } IndexExpression;
 
-
 typedef struct InfixExpression : Expression {
-  InfixExpression();
-  ~InfixExpression() = default;
+    InfixExpression();
+    ~InfixExpression() = default;
 
-  Token token;
-  std::string _operator;
-  std::shared_ptr<Expression> _left;
-  std::shared_ptr<Expression> _right;
+    Token token;
+    std::string _operator;
+    std::shared_ptr<Expression> _left;
+    std::shared_ptr<Expression> _right;
 
-  void setExpressionNode(Token);
-  std::string printString();
+    void setExpressionNode(Token);
+    std::string printString();
 } InfixExpression;
 
-
 typedef struct IntegerLiteral : Expression {
-  IntegerLiteral();
+    IntegerLiteral();
 
-  Token token;
-  int value;
+    Token token;
+    int value;
 
-  void setExpressionNode(Token);
-  inline std::string printString() { return std::to_string(this->value); };
+    void setExpressionNode(Token);
+    inline std::string printString() { return std::to_string(this->value); };
 } IntegerLiteral;
 
-
 typedef struct LetStatement : Statement {
-  LetStatement();
-  ~LetStatement() = default;
+    LetStatement();
+    ~LetStatement() = default;
 
-  Token token;
-  std::shared_ptr<IdentifierLiteral> name;
-  std::shared_ptr<Expression> value;
+    Token token;
+    std::shared_ptr<IdentifierLiteral> name;
+    std::shared_ptr<Expression> value;
 
-  std::string printString();
+    std::string printString();
 } LetStatement;
 
-
 typedef struct PostfixExpression : Expression {
-  PostfixExpression();
-  ~PostfixExpression() = default;
+    PostfixExpression();
+    ~PostfixExpression() = default;
 
-  Token token;
-  std::string _operator;
-  std::shared_ptr<Expression> _left;
+    Token token;
+    std::string _operator;
+    std::shared_ptr<Expression> _left;
 
-  void setExpressionNode(Token);
-  std::string printString();
+    void setExpressionNode(Token);
+    std::string printString();
 } PostfixExpression;
 
-
 typedef struct PrefixExpression : Expression {
-  PrefixExpression();
-  ~PrefixExpression() = default;
+    PrefixExpression();
+    ~PrefixExpression() = default;
 
-  Token token;
-  std::string _operator;
-  std::shared_ptr<Expression> _right;
+    Token token;
+    std::string _operator;
+    std::shared_ptr<Expression> _right;
 
-  void setExpressionNode(Token);
-  std::string printString();
+    void setExpressionNode(Token);
+    std::string printString();
 } PrefixExpression;
 
-
 typedef struct ReturnStatement : Statement {
-  ReturnStatement();
-  ~ReturnStatement() = default;
+    ReturnStatement();
+    ~ReturnStatement() = default;
 
-  Token token;
-  std::shared_ptr<Expression> returnValue;
+    Token token;
+    std::shared_ptr<Expression> returnValue;
 
-  std::string printString();
+    std::string printString();
 } ReturnStatement;
 
-
 typedef struct StringLiteral : Expression {
-  StringLiteral();
+    StringLiteral();
 
-  Token token;
-  std::string value;
+    Token token;
+    std::string value;
 
-  void setExpressionNode(Token);
-  inline std::string printString() { return this->value; };
+    void setExpressionNode(Token);
+    inline std::string printString() { return this->value; };
 } StringLiteral;
 
-
 typedef struct WhileExpression : Expression {
-  WhileExpression();
-  ~WhileExpression() = default;
+    WhileExpression();
+    ~WhileExpression() = default;
 
-  Token token;
-  std::shared_ptr<Expression> condition;
-  std::shared_ptr<BlockStatement> body;
+    Token token;
+    std::shared_ptr<Expression> condition;
+    std::shared_ptr<BlockStatement> body;
 
 } WhileExpression;
 
-
 const std::unordered_map<int, std::string> StatementMap = {
-  {0, "Identifier Statement"},
-  {1, "Function Statement"},
-  {2, "Let Statement"},
-  {3, "Return Statement"},
-  {4, "Expression Statement"},
-  {5, "Block Statement"},
-  {6, "Assignment Expression Statement"},
+    {0, "Identifier Statement"},
+    {1, "Function Statement"},
+    {2, "Let Statement"},
+    {3, "Return Statement"},
+    {4, "Expression Statement"},
+    {5, "Block Statement"},
+    {6, "Assignment Expression Statement"},
 };
-
 
 const std::unordered_map<int, std::string> ExpressionMap = {
-  {0, "Integer Literal"},
-  {1, "Float Literal"},
-  {2, "Boolean Literal"},
-  {3, "String Literal"},
-  {4, "IdentifierLiteral"},
-  {5, "Prefix Expression"},
-  {6, "Infix Expression"},
-  {7, "If Expression"},
-  {8, "Function Literal"},
-  {9, "Call Expression"},
-  {10, "Array Literal"},
-  {11, "Index Expression"},
+    {0, "Integer Literal"},  {1, "Float Literal"},     {2, "Boolean Literal"},
+    {3, "String Literal"},   {4, "IdentifierLiteral"}, {5, "Prefix Expression"},
+    {6, "Infix Expression"}, {7, "If Expression"},     {8, "Function Literal"},
+    {9, "Call Expression"},  {10, "Array Literal"},    {11, "Index Expression"},
 };
-
 
 const std::unordered_map<int, std::string> DatatypeMap = {
-  {0, "int"},
-  {1, "float"},
-  {2, "boolean"},
-  {3, "string"},
-  {4, "void"},
+    {0, "int"}, {1, "float"}, {2, "boolean"}, {3, "string"}, {4, "void"},
 };
 
-
 const struct Precedences {
-  int LOWEST {1};
-  int EQUALS {2};
-  int LESSGREATER {3};
-  int SUM {4};
-  int PRODUCT {5};
-  int PREFIX {6};
-  int CALL {7};
-  int INDEX {8};
+    int LOWEST{1};
+    int EQUALS{2};
+    int LESSGREATER{3};
+    int SUM{4};
+    int PRODUCT{5};
+    int PREFIX{6};
+    int CALL{7};
+    int INDEX{8};
 } Precedences{};
 
-
 const std::unordered_map<std::string, int> precedencesMap = {
-  {TokenType.EQ, Precedences.EQUALS},
-  {TokenType.NOT_EQ, Precedences.EQUALS},
-  {TokenType.LT, Precedences.LESSGREATER},
-  {TokenType.GT, Precedences.LESSGREATER},
-  {TokenType.PLUS, Precedences.SUM},
-  {TokenType.INCREMENT, Precedences.SUM},
-  {TokenType.PLUS_EQ, Precedences.SUM},
-  {TokenType.MINUS, Precedences.SUM},
-  {TokenType.DECREMENT, Precedences.SUM},
-  {TokenType.MINUS_EQ, Precedences.SUM},
-  {TokenType.SLASH, Precedences.PRODUCT},
-  {TokenType.DIV_EQ, Precedences.PRODUCT},
-  {TokenType.ASTERISK, Precedences.PRODUCT},
-  {TokenType.MULT_EQ, Precedences.PRODUCT},
-  {TokenType.LPAREN, Precedences.CALL},
-  {TokenType.PERIOD, Precedences.CALL},
-  {TokenType.LBRACKET, Precedences.INDEX},
+    {TokenType.EQ, Precedences.EQUALS},        {TokenType.NOT_EQ, Precedences.EQUALS},
+    {TokenType.LT, Precedences.LESSGREATER},   {TokenType.GT, Precedences.LESSGREATER},
+    {TokenType.PLUS, Precedences.SUM},         {TokenType.INCREMENT, Precedences.SUM},
+    {TokenType.PLUS_EQ, Precedences.SUM},      {TokenType.MINUS, Precedences.SUM},
+    {TokenType.DECREMENT, Precedences.SUM},    {TokenType.MINUS_EQ, Precedences.SUM},
+    {TokenType.SLASH, Precedences.PRODUCT},    {TokenType.DIV_EQ, Precedences.PRODUCT},
+    {TokenType.ASTERISK, Precedences.PRODUCT}, {TokenType.MULT_EQ, Precedences.PRODUCT},
+    {TokenType.LPAREN, Precedences.CALL},      {TokenType.PERIOD, Precedences.CALL},
+    {TokenType.LBRACKET, Precedences.INDEX},
 };

--- a/src/builtins.cpp
+++ b/src/builtins.cpp
@@ -1,121 +1,115 @@
-#include "object.hpp"
 #include "builtins.hpp"
+
+#include "object.hpp"
+
 #include <iostream>
 
 using namespace std;
 
-
-shared_ptr<Object> evalBuiltinFunction(shared_ptr<Object> fn, vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  shared_ptr<Builtin> bf = static_pointer_cast<Builtin>(fn);
-  switch (bf->builtin_type) {
-    case builtin_len:
-      return built_in_len(args, env);
-    case builtin_print:
-      return built_in_print(args, env);
-    case builtin_max:
-      return built_in_max(args, env);
-    case builtin_min:
-      return built_in_min(args, env);
-    case builtin_push:
-      return built_in_push(args, env);
-    case builtin_pop:
-      return built_in_pop(args, env);
-    default:
-      return newError("not a valid function");
-  }
+shared_ptr<Object> evalBuiltinFunction(
+    shared_ptr<Object> fn, vector<shared_ptr<Object>> args, shared_ptr<Environment> env
+) {
+    shared_ptr<Builtin> bf = static_pointer_cast<Builtin>(fn);
+    switch (bf->builtin_type) {
+        case builtin_len:
+            return built_in_len(args, env);
+        case builtin_print:
+            return built_in_print(args, env);
+        case builtin_max:
+            return built_in_max(args, env);
+        case builtin_min:
+            return built_in_min(args, env);
+        case builtin_push:
+            return built_in_push(args, env);
+        case builtin_pop:
+            return built_in_pop(args, env);
+        default:
+            return newError("not a valid function");
+    }
 };
 
-
 shared_ptr<Object> built_in_len(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  if (args.size() != 1) {
-    return newError(
-      "wrong number of arguments for len(). Expected 1, got " + to_string(args.size())
-    );
-  }
-  if (args[0]->inspectType() == ObjectType.STRING_OBJ) {
-    shared_ptr<String> s = static_pointer_cast<String>(args[0]);
-    shared_ptr<Integer> newi (new Integer(s->value.length()));
-    env->gc.push_back(newi);
-    return newi;
-  }
-  if (args[0]->inspectType() == ObjectType.ARRAY_OBJ) {
-    shared_ptr<Array> a = static_pointer_cast<Array>(args[0]);
-    shared_ptr<Integer> newi (new Integer(a->elements.size()));
-    env->gc.push_back(newi);
-    return newi;
-  }
+    if (args.size() != 1) {
+        return newError(
+            "wrong number of arguments for len(). Expected 1, got " + to_string(args.size())
+        );
+    }
+    if (args[0]->inspectType() == ObjectType.STRING_OBJ) {
+        shared_ptr<String> s = static_pointer_cast<String>(args[0]);
+        shared_ptr<Integer> newi(new Integer(s->value.length()));
+        env->gc.push_back(newi);
+        return newi;
+    }
+    if (args[0]->inspectType() == ObjectType.ARRAY_OBJ) {
+        shared_ptr<Array> a = static_pointer_cast<Array>(args[0]);
+        shared_ptr<Integer> newi(new Integer(a->elements.size()));
+        env->gc.push_back(newi);
+        return newi;
+    }
 
-  return nullptr;
+    return nullptr;
 }
 
 shared_ptr<Object> built_in_print(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  for (auto arg : args)
-    cout << arg->inspectObject() << '\n';
-  return nullptr;
+    for (auto arg : args)
+        cout << arg->inspectObject() << '\n';
+    return nullptr;
 }
-
 
 shared_ptr<Object> built_in_max(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  int result{};
-  if (args.size() == 1)
-    return args[0];
-  
-  for (auto arg : args) {
-    shared_ptr<Integer> i = static_pointer_cast<Integer>(arg);
-    int num = stoi(i->inspectObject());
-    num > result ? result = num : result = result;
-  }
-  shared_ptr<String> news (new String(to_string(result)));
-  env->gc.push_back(news);
-  return news;
-}
+    int result{};
+    if (args.size() == 1) return args[0];
 
+    for (auto arg : args) {
+        shared_ptr<Integer> i = static_pointer_cast<Integer>(arg);
+        int num = stoi(i->inspectObject());
+        num > result ? result = num : result = result;
+    }
+    shared_ptr<String> news(new String(to_string(result)));
+    env->gc.push_back(news);
+    return news;
+}
 
 shared_ptr<Object> built_in_min(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  int result{};
-  if (args.size() == 1)
-    return args[0];
-  
-  for (auto arg : args) {
-    shared_ptr<Integer> i = static_pointer_cast<Integer>(arg);
-    int num = stoi(i->inspectObject());
-    num < result ? result = num : result = result;
-  }
-  shared_ptr<String> news (new String(to_string(result)));
-  env->gc.push_back(news);
-  return news;
-}
+    int result{};
+    if (args.size() == 1) return args[0];
 
+    for (auto arg : args) {
+        shared_ptr<Integer> i = static_pointer_cast<Integer>(arg);
+        int num = stoi(i->inspectObject());
+        num < result ? result = num : result = result;
+    }
+    shared_ptr<String> news(new String(to_string(result)));
+    env->gc.push_back(news);
+    return news;
+}
 
 shared_ptr<Object> built_in_push(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  if (args.size() != 2)
-    return newError(
-      "Wrong number of arguments for push(). Expected 2, got " + to_string(args.size())
-    );
-  if (args[0]->inspectType() != ObjectType.ARRAY_OBJ)
-    return newError(
-      "Argument 1 to push() must be ARRAY. Instead got " + args[0]->inspectType()
-    );
-  std::vector<shared_ptr<Object>> arg = static_pointer_cast<Array>(args[0])->elements;
-  arg.push_back(args[1]);
-  shared_ptr<Array> arr (new Array(arg));
-  env->gc.push_back(arr);
-  return arr;
+    if (args.size() != 2)
+        return newError(
+            "Wrong number of arguments for push(). Expected 2, got " + to_string(args.size())
+        );
+    if (args[0]->inspectType() != ObjectType.ARRAY_OBJ)
+        return newError(
+            "Argument 1 to push() must be ARRAY. Instead got " + args[0]->inspectType()
+        );
+    std::vector<shared_ptr<Object>> arg = static_pointer_cast<Array>(args[0])->elements;
+    arg.push_back(args[1]);
+    shared_ptr<Array> arr(new Array(arg));
+    env->gc.push_back(arr);
+    return arr;
 }
 
-
 shared_ptr<Object> built_in_pop(vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  if (args.size() != 1)
-    return newError(
-      "Wrong number of arguments for pop(). Expected 1, got " + to_string(args.size())
-    );
-  if (args[0]->inspectType() != ObjectType.ARRAY_OBJ)
-    return newError(
-      "Argument 1 to pop() must be ARRAY. Instead got " + args[0]->inspectType()
-    );
-  std::vector<shared_ptr<Object>> arg = static_pointer_cast<Array>(args[0])->elements;
-  arg.pop_back();
-  shared_ptr<Array> arr (new Array(arg));
-  env->gc.push_back(arr);
-  return arr;
+    if (args.size() != 1)
+        return newError(
+            "Wrong number of arguments for pop(). Expected 1, got " + to_string(args.size())
+        );
+    if (args[0]->inspectType() != ObjectType.ARRAY_OBJ)
+        return newError("Argument 1 to pop() must be ARRAY. Instead got " + args[0]->inspectType());
+    std::vector<shared_ptr<Object>> arg = static_pointer_cast<Array>(args[0])->elements;
+    arg.pop_back();
+    shared_ptr<Array> arr(new Array(arg));
+    env->gc.push_back(arr);
+    return arr;
 }

--- a/src/builtins.hpp
+++ b/src/builtins.hpp
@@ -1,45 +1,41 @@
 #pragma once
 #include "object.hpp"
 
-std::shared_ptr<Object> evalBuiltinFunction(std::shared_ptr<Object>, std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_len(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_print(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_max(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_min(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_pop(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
-std::shared_ptr<Object> built_in_push(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    evalBuiltinFunction(std::shared_ptr<Object>, std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_len(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_print(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_max(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_min(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_pop(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
+std::shared_ptr<Object>
+    built_in_push(std::vector<std::shared_ptr<Object>>, std::shared_ptr<Environment>);
 std::shared_ptr<Object> newError(std::string);
 
-
 typedef struct Builtin : Object {
-  int builtin_type;
-  int function_type;
+    int builtin_type;
+    int function_type;
 
-  Builtin() {
-    this->type = BUILTIN_OBJ;
-  }
+    Builtin() { this->type = BUILTIN_OBJ; }
 
-  inline std::string inspectType() { return ObjectType.BUILTIN_OBJ; };
-  inline std::string inspectObject() { return "builtin function"; };
+    inline std::string inspectType() { return ObjectType.BUILTIN_OBJ; };
+    inline std::string inspectObject() { return "builtin function"; };
 } Builtin;
 
-
 enum BuiltinFunctions {
-  builtin_len,
-  builtin_print,
-  builtin_max,
-  builtin_min,
-  builtin_pop,
-  builtin_push,
+    builtin_len,
+    builtin_print,
+    builtin_max,
+    builtin_min,
+    builtin_pop,
+    builtin_push,
 };
 
-
-const std::unordered_map<std::string, int> builtins {
-  {"len", builtin_len},
-  {"print", builtin_print},
-  {"max", builtin_max},
-  {"min", builtin_min},
-  {"pop", builtin_pop},
-  {"push", builtin_push}
-};
-
+const std::unordered_map<std::string, int> builtins{{"len", builtin_len}, {"print", builtin_print},
+                                                    {"max", builtin_max}, {"min", builtin_min},
+                                                    {"pop", builtin_pop}, {"push", builtin_push}};

--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -1,749 +1,719 @@
 #include "evaluator.hpp"
+
 #include "builtins.hpp"
+
 #include <iostream>
 #include <memory>
 
 using namespace std;
 
 // GLOBALS
-shared_ptr<Boolean> TRUE_BOOL ( new Boolean(true) );
-shared_ptr<Boolean> FALSE_BOOL ( new Boolean(false) );
-shared_ptr<Null> _nullptr ( new Null{} );
+shared_ptr<Boolean> TRUE_BOOL(new Boolean(true));
+shared_ptr<Boolean> FALSE_BOOL(new Boolean(false));
+shared_ptr<Null> _nullptr(new Null{});
 shared_ptr<Environment> err_gc = nullptr;
 
+void setErrorGarbageCollector(shared_ptr<Environment>* env) { err_gc = *env; };
 
-void setErrorGarbageCollector(shared_ptr<Environment>* env) { 
-  err_gc = *env; 
-};
-
-shared_ptr<Object> applyFunction(shared_ptr<Object> fn, vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
-  if(fn-> type == FUNCTION_OBJ) {
-    shared_ptr<Function> func;
-    try {
-      func = dynamic_pointer_cast<Function>(fn);
-    }
-    catch (...) {
-      ostringstream ss;
-      ss << " not a function: " << fn->inspectType();
-      return newError(ss.str());
-    }
-    shared_ptr<Environment> newEnv = extendFunction(func, args);
-    shared_ptr<Object> evaluated = evalNode(func->body, newEnv);
-    if (evaluated == nullptr)
-      return nullptr;
-    return unwrapReturnValue(evaluated);
-  }
-  else if (fn->type == BUILTIN_OBJ)
-    return evalBuiltinFunction(fn, args, env);
-  return newError("not a function: " + fn->inspectType());
+shared_ptr<Object>
+applyFunction(shared_ptr<Object> fn, vector<shared_ptr<Object>> args, shared_ptr<Environment> env) {
+    if (fn->type == FUNCTION_OBJ) {
+        shared_ptr<Function> func;
+        try {
+            func = dynamic_pointer_cast<Function>(fn);
+        } catch (...) {
+            ostringstream ss;
+            ss << " not a function: " << fn->inspectType();
+            return newError(ss.str());
+        }
+        shared_ptr<Environment> newEnv = extendFunction(func, args);
+        shared_ptr<Object> evaluated = evalNode(func->body, newEnv);
+        if (evaluated == nullptr) return nullptr;
+        return unwrapReturnValue(evaluated);
+    } else if (fn->type == BUILTIN_OBJ) return evalBuiltinFunction(fn, args, env);
+    return newError("not a function: " + fn->inspectType());
 }
 
-
-shared_ptr<Object> evalArrayIndexExpression(shared_ptr<Object> arr, shared_ptr<Object> index, shared_ptr<Environment> env) {
-  shared_ptr<Array> arrayObject = static_pointer_cast<Array>(arr);
-  shared_ptr<Integer> intObject = static_pointer_cast<Integer>(index);
-  int idx = intObject->value;
-  int max = arrayObject->elements.size();
-  // evaluate negative (reverse) index
-  if (idx < 0) {
-    if (idx + max < 0) {
-      ostringstream ss;
-      ss << "index out of range.";
-      return newError(ss.str());
+shared_ptr<Object> evalArrayIndexExpression(
+    shared_ptr<Object> arr, shared_ptr<Object> index, shared_ptr<Environment> env
+) {
+    shared_ptr<Array> arrayObject = static_pointer_cast<Array>(arr);
+    shared_ptr<Integer> intObject = static_pointer_cast<Integer>(index);
+    int idx = intObject->value;
+    int max = arrayObject->elements.size();
+    // evaluate negative (reverse) index
+    if (idx < 0) {
+        if (idx + max < 0) {
+            ostringstream ss;
+            ss << "index out of range.";
+            return newError(ss.str());
+        }
+        return arrayObject->elements[idx + max];
     }
-    return arrayObject->elements[idx + max];
-  }
-  if (idx > max - 1) {
-    ostringstream ss;
-    ss << "index out of range.";
-    return newError(ss.str());
-  }
-  return arrayObject->elements[idx];
+    if (idx > max - 1) {
+        ostringstream ss;
+        ss << "index out of range.";
+        return newError(ss.str());
+    }
+    return arrayObject->elements[idx];
 }
-
 
 shared_ptr<Object> evalAssignmentExpression(
     string op, shared_ptr<Object> oldVal, shared_ptr<Object> val, shared_ptr<Environment> env
-  ) {
-  if (val->type == INTEGER_OBJ) {
-    shared_ptr<Integer> oldv = static_pointer_cast<Integer>(oldVal);
-    shared_ptr<Integer> v = static_pointer_cast<Integer>(val);
-    if (op == "+=") {
-      shared_ptr<Integer> newi (new Integer(oldv->value + v->value));
-      env->gc.push_back(newi);
-      return newi;
+) {
+    if (val->type == INTEGER_OBJ) {
+        shared_ptr<Integer> oldv = static_pointer_cast<Integer>(oldVal);
+        shared_ptr<Integer> v = static_pointer_cast<Integer>(val);
+        if (op == "+=") {
+            shared_ptr<Integer> newi(new Integer(oldv->value + v->value));
+            env->gc.push_back(newi);
+            return newi;
+        } else if (op == "-=") {
+            shared_ptr<Integer> newi(new Integer(oldv->value - v->value));
+            env->gc.push_back(newi);
+            return newi;
+        } else if (op == "*=") {
+            shared_ptr<Integer> newi(new Integer(oldv->value * v->value));
+            env->gc.push_back(newi);
+            return newi;
+        } else if (op == "/=") {
+            shared_ptr<Integer> newi(new Integer(oldv->value / v->value));
+            env->gc.push_back(newi);
+            return newi;
+        }
+    } else if (val->type == STRING_OBJ) {
+        shared_ptr<String> olds = static_pointer_cast<String>(oldVal);
+        shared_ptr<String> s = static_pointer_cast<String>(val);
+        if (op == "+=") {
+            shared_ptr<String> news(new String(olds->value + s->value));
+            env->gc.push_back(news);
+            return news;
+        } else {
+            return newError("incompatible assignment operator: " + val->inspectType() + " " + op);
+        }
     }
-    else if (op == "-=") {
-      shared_ptr<Integer> newi (new Integer(oldv->value - v->value));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    else if (op == "*=") {
-      shared_ptr<Integer> newi (new Integer(oldv->value * v->value));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    else if (op == "/=") {
-      shared_ptr<Integer> newi (new Integer(oldv->value / v->value));
-      env->gc.push_back(newi);
-      return newi;
-    }
-  }
-  else if (val->type == STRING_OBJ) {
-    shared_ptr<String> olds = static_pointer_cast<String>(oldVal);
-    shared_ptr<String> s = static_pointer_cast<String>(val);
-    if (op == "+=") {
-      shared_ptr<String> news (new String(olds->value + s->value));
-      env->gc.push_back(news);
-      return news;
-    }
-    else {
-      return newError("incompatible assignment operator: " + val->inspectType() + " " + op);
-    }
-  }
-  return nullptr;
+    return nullptr;
 }
-
 
 shared_ptr<Object> evalBangOperatorExpression(shared_ptr<Object> _right) {
-  switch (_right->type) {
-    case BOOLEAN_TRUE:
-      return static_pointer_cast<Object>(FALSE_BOOL);
-    case BOOLEAN_FALSE:
-      return static_pointer_cast<Object>(TRUE_BOOL);
-    case NULL_OBJ:
-      return static_pointer_cast<Object>(TRUE_BOOL);
-    default:
-      return static_pointer_cast<Object>(FALSE_BOOL);
-  }
+    switch (_right->type) {
+        case BOOLEAN_TRUE:
+            return static_pointer_cast<Object>(FALSE_BOOL);
+        case BOOLEAN_FALSE:
+            return static_pointer_cast<Object>(TRUE_BOOL);
+        case NULL_OBJ:
+            return static_pointer_cast<Object>(TRUE_BOOL);
+        default:
+            return static_pointer_cast<Object>(FALSE_BOOL);
+    }
 }
 
+vector<shared_ptr<Object>>
+evalCallExpressions(vector<shared_ptr<Expression>> expr, shared_ptr<Environment> env) {
+    vector<shared_ptr<Object>> result{};
 
-vector<shared_ptr<Object>> evalCallExpressions(vector<shared_ptr<Expression>> expr, shared_ptr<Environment> env) {
-  vector<shared_ptr<Object>> result{};
-
-  for (auto e : expr) {
-    shared_ptr<Object> evaluated = evalNode(e, env);
-    if (isError(evaluated)) {
-      result.push_back(evaluated);
-      return result;
+    for (auto e : expr) {
+        shared_ptr<Object> evaluated = evalNode(e, env);
+        if (isError(evaluated)) {
+            result.push_back(evaluated);
+            return result;
+        }
+        result.push_back(evaluated);
     }
-    result.push_back(evaluated);
-  }
-  return result;
+    return result;
 }
 
-
-shared_ptr<Object> evalExpressions(shared_ptr<Expression> expr, shared_ptr<Environment> env = nullptr) {
-  switch (expr->type) {
-    case arrayLiteral: {
-      shared_ptr<ArrayLiteral> a = static_pointer_cast<ArrayLiteral>(expr);
-      vector<shared_ptr<Object>>elements = evalCallExpressions(a->elements, env);
-      if (elements.size() == 1 && isError(elements[0]))
-        return elements[0];
-      shared_ptr<Array> newa (new Array(elements));
-      env->gc.push_back(newa);
-      return newa;
+shared_ptr<Object>
+evalExpressions(shared_ptr<Expression> expr, shared_ptr<Environment> env = nullptr) {
+    switch (expr->type) {
+        case arrayLiteral:
+            {
+                shared_ptr<ArrayLiteral> a = static_pointer_cast<ArrayLiteral>(expr);
+                vector<shared_ptr<Object>> elements = evalCallExpressions(a->elements, env);
+                if (elements.size() == 1 && isError(elements[0])) return elements[0];
+                shared_ptr<Array> newa(new Array(elements));
+                env->gc.push_back(newa);
+                return newa;
+            }
+        case booleanExpression:
+            {
+                shared_ptr<BooleanLiteral> b = static_pointer_cast<BooleanLiteral>(expr);
+                shared_ptr<Boolean> newb = nativeToBoolean(b->value);
+                return newb;
+            }
+        case callExpression:
+            {
+                shared_ptr<CallExpression> ce = static_pointer_cast<CallExpression>(expr);
+                shared_ptr<Object> func = evalNode(ce->_function, env);
+                if (isError(func)) return func;
+                vector<shared_ptr<Object>> args = evalCallExpressions(ce->arguments, env);
+                if (args.size() == 1 && isError(args[0])) return args[0];
+                return applyFunction(func, args, env);
+            }
+        case doExpression:
+            {
+                shared_ptr<DoExpression> de = static_pointer_cast<DoExpression>(expr);
+                shared_ptr<Loop> loop(new Loop(doLoop, de->body, env));
+                env->gc.push_back(loop);
+                loop->condition = de->condition;
+                return evalLoop(loop);
+                break;
+            }
+        case floatLiteral:
+            {
+                shared_ptr<FloatLiteral> f = static_pointer_cast<FloatLiteral>(expr);
+                shared_ptr<Float> newf(new Float(f->value));
+                env->gc.push_back(newf);
+                return newf;
+            }
+        case forExpression:
+            {
+                shared_ptr<ForExpression> fe = dynamic_pointer_cast<ForExpression>(expr);
+                shared_ptr<Loop> loop(new Loop(forLoop, fe->body, env));
+                env->gc.push_back(loop);
+                loop->start = static_pointer_cast<IntegerLiteral>(fe->start)->value;
+                loop->end = static_pointer_cast<IntegerLiteral>(fe->end)->value;
+                loop->increment = static_pointer_cast<IntegerLiteral>(fe->increment)->value;
+                for (auto stmt : fe->statements) {
+                    evalNode(stmt, loop->env);
+                    loop->statements.push_back(stmt);
+                }
+                return evalLoop(loop);
+                break;
+            }
+        case functionLiteral:
+            {
+                shared_ptr<FunctionLiteral> fl = static_pointer_cast<FunctionLiteral>(expr);
+                shared_ptr<Function> newf(new Function(fl->parameters, fl->body, env));
+                env->gc.push_back(newf);
+                env->set(fl->name->value, newf);
+                break;
+            }
+        case hashLiteral:
+            {
+                shared_ptr<HashLiteral> h = static_pointer_cast<HashLiteral>(expr);
+                return evalHashLiteral(h, env);
+            }
+        case identifier:
+            {
+                shared_ptr<IdentifierLiteral> i = static_pointer_cast<IdentifierLiteral>(expr);
+                shared_ptr<Object> newi = evalIdentifier(i, env);
+                return newi;
+            }
+        case ifExpression:
+            {
+                shared_ptr<IfExpression> i = static_pointer_cast<IfExpression>(expr);
+                shared_ptr<Object> cond = evalIfExpression(i, env);
+                return cond;
+            }
+        case indexExpression:
+            {
+                shared_ptr<IndexExpression> ie = static_pointer_cast<IndexExpression>(expr);
+                shared_ptr<Object> left = evalNode(ie->_left, env);
+                if (isError(left)) return left;
+                shared_ptr<Object> index = evalNode(ie->index, env);
+                if (isError(index)) return index;
+                return evalIndexExpression(left, index, env);
+            }
+        case infixExpression:
+            {
+                shared_ptr<InfixExpression> i = static_pointer_cast<InfixExpression>(expr);
+                shared_ptr<Object> left = evalNode(i->_left, env);
+                if (isError(left)) return left;
+                shared_ptr<Object> right = evalNode(i->_right, env);
+                if (isError(right)) return right;
+                shared_ptr<Object> ni = evalInfixExpression(i->_operator, left, right, env);
+                return ni;
+            }
+        case integerLiteral:
+            {
+                shared_ptr<IntegerLiteral> i = static_pointer_cast<IntegerLiteral>(expr);
+                shared_ptr<Integer> newi(new Integer(i->value));
+                env->gc.push_back(newi);
+                return newi;
+            }
+        case postfixExpression:
+            {
+                shared_ptr<PostfixExpression> p = static_pointer_cast<PostfixExpression>(expr);
+                shared_ptr<Object> left = evalNode(p->_left, env);
+                if (isError(left)) return left;
+                if (left->type != INTEGER_OBJ)
+                    return newError(p->_left->literal + " is not an integer.");
+                shared_ptr<IdentifierLiteral> id = static_pointer_cast<IdentifierLiteral>(p->_left);
+                string name = id->value;
+                shared_ptr<Object> val = env->get(name);
+                shared_ptr<Object> np = evalPostfixExpression(p->_operator, val, env);
+                env->set(name, np);
+                return np;
+            }
+        case prefixExpression:
+            {
+                shared_ptr<PrefixExpression> p = static_pointer_cast<PrefixExpression>(expr);
+                shared_ptr<Object> right = evalNode(p->_right, env);
+                if (isError(right)) return right;
+                shared_ptr<Object> np = evalPrefixExpression(p->_operator, right, env);
+                return np;
+            }
+        case stringLiteral:
+            {
+                shared_ptr<StringLiteral> s = static_pointer_cast<StringLiteral>(expr);
+                shared_ptr<String> news(new String(s->value));
+                env->gc.push_back(news);
+                return news;
+            }
+        case whileExpression:
+            {
+                shared_ptr<WhileExpression> wexpr = dynamic_pointer_cast<WhileExpression>(expr);
+                shared_ptr<Loop> loop(new Loop(whileLoop, wexpr->body, env));
+                loop->condition = wexpr->condition;
+                env->gc.push_back(loop);
+                return evalLoop(loop);
+                break;
+            }
     }
-    case booleanExpression: {
-      shared_ptr<BooleanLiteral> b = static_pointer_cast<BooleanLiteral>(expr);
-      shared_ptr<Boolean> newb = nativeToBoolean(b->value);
-      return newb;
-    }
-    case callExpression: {
-      shared_ptr<CallExpression> ce = static_pointer_cast<CallExpression>(expr);
-      shared_ptr<Object> func = evalNode(ce->_function, env);
-      if (isError(func))
-        return func;
-      vector<shared_ptr<Object>> args = evalCallExpressions(ce->arguments, env);
-      if (args.size() == 1 && isError(args[0]))
-        return args[0];
-      return applyFunction(func, args, env);
-    }
-    case doExpression: {
-      shared_ptr<DoExpression> de = static_pointer_cast<DoExpression>(expr);
-      shared_ptr<Loop> loop (new Loop(doLoop, de->body, env));
-      env->gc.push_back(loop);
-      loop->condition = de->condition;
-      return evalLoop(loop);
-      break;
-    }
-    case floatLiteral: {
-      shared_ptr<FloatLiteral> f = static_pointer_cast<FloatLiteral>(expr);
-      shared_ptr<Float> newf (new Float(f->value));
-      env->gc.push_back(newf);
-      return newf;
-    }
-    case forExpression: {
-      shared_ptr<ForExpression> fe = dynamic_pointer_cast<ForExpression>(expr);
-      shared_ptr<Loop> loop (new Loop(forLoop, fe->body, env));
-      env->gc.push_back(loop);
-      loop->start = static_pointer_cast<IntegerLiteral>(fe->start)->value;
-      loop->end = static_pointer_cast<IntegerLiteral>(fe->end)->value;
-      loop->increment = static_pointer_cast<IntegerLiteral>(fe->increment)->value;
-      for (auto stmt : fe->statements) {
-        evalNode(stmt, loop->env);
-        loop->statements.push_back(stmt);
-      }
-      return evalLoop(loop);
-      break;
-    }
-    case functionLiteral: {
-      shared_ptr<FunctionLiteral> fl = static_pointer_cast<FunctionLiteral>(expr);
-      shared_ptr<Function> newf (new Function(fl->parameters, fl->body, env));
-      env->gc.push_back(newf);
-      env->set(fl->name->value, newf);
-      break;
-    }
-    case hashLiteral: {
-      shared_ptr<HashLiteral> h = static_pointer_cast<HashLiteral>(expr);
-      return evalHashLiteral(h, env);
-    }
-    case identifier: {
-      shared_ptr<IdentifierLiteral> i = static_pointer_cast<IdentifierLiteral>(expr);
-      shared_ptr<Object> newi = evalIdentifier(i, env);
-      return newi;
-    }
-    case ifExpression: {
-      shared_ptr<IfExpression> i = static_pointer_cast<IfExpression>(expr);
-      shared_ptr<Object> cond = evalIfExpression(i, env);
-      return cond;
-    }
-    case indexExpression: {
-      shared_ptr<IndexExpression> ie = static_pointer_cast<IndexExpression>(expr);
-      shared_ptr<Object> left = evalNode(ie->_left, env);
-      if (isError(left))
-        return left;
-      shared_ptr<Object> index = evalNode(ie->index, env);
-      if (isError(index))
-        return index;
-      return evalIndexExpression(left, index, env);
-    }
-    case infixExpression: {
-      shared_ptr<InfixExpression> i = static_pointer_cast<InfixExpression>(expr);
-      shared_ptr<Object> left = evalNode(i->_left, env);
-      if (isError(left))
-        return left;
-      shared_ptr<Object> right = evalNode(i->_right, env);
-      if (isError(right))
-        return right;
-      shared_ptr<Object> ni = evalInfixExpression(i->_operator, left, right, env);
-      return ni;
-    }
-    case integerLiteral: {
-      shared_ptr<IntegerLiteral> i = static_pointer_cast<IntegerLiteral>(expr);
-      shared_ptr<Integer> newi (new Integer(i->value));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    case postfixExpression: {
-      shared_ptr<PostfixExpression> p = static_pointer_cast<PostfixExpression>(expr);
-      shared_ptr<Object> left = evalNode(p->_left, env);
-      if (isError(left))
-        return left;
-      if (left->type != INTEGER_OBJ)
-        return newError(p->_left->literal + " is not an integer.");
-      shared_ptr<IdentifierLiteral> id = static_pointer_cast<IdentifierLiteral>(p->_left);
-      string name = id->value;
-      shared_ptr<Object> val = env->get(name);
-      shared_ptr<Object> np = evalPostfixExpression(p->_operator, val, env);
-      env->set(name, np);
-      return np;
-    }
-    case prefixExpression: {
-      shared_ptr<PrefixExpression> p = static_pointer_cast<PrefixExpression>(expr);
-      shared_ptr<Object> right = evalNode(p->_right, env);
-      if (isError(right))
-        return right;
-      shared_ptr<Object> np = evalPrefixExpression(p->_operator, right, env);
-      return np;
-    }
-    case stringLiteral: {
-      shared_ptr<StringLiteral> s = static_pointer_cast<StringLiteral>(expr);
-      shared_ptr<String> news (new String(s->value));
-      env->gc.push_back(news);
-      return news;
-    }
-    case whileExpression: {
-      shared_ptr<WhileExpression> wexpr = dynamic_pointer_cast<WhileExpression>(expr);
-      shared_ptr<Loop> loop (new Loop(whileLoop, wexpr->body, env));
-      loop->condition = wexpr->condition;
-      env->gc.push_back(loop);
-      return evalLoop(loop);
-      break;
-    }
-  }
-  return nullptr;
+    return nullptr;
 }
-
 
 shared_ptr<Object> evalHashIndexExpression(shared_ptr<Object> hash, shared_ptr<Object> index) {
-  shared_ptr<Hash> hashObject = static_pointer_cast<Hash>(hash);
-  size_t key;
-  shared_ptr<HashPair> pair;
-  if (index->inspectType() == ObjectType.BOOLEAN_OBJ)
-    key = hashKey(static_pointer_cast<Boolean>(index));
-  else if (index->inspectType() == ObjectType.INTEGER_OBJ)
-    key = hashKey(static_pointer_cast<Integer>(index));
-  else if (index->inspectType() == ObjectType.STRING_OBJ)
-    key = hashKey(static_pointer_cast<String>(index));
-  else
-    return newError("unusable as hash key: " + index->inspectType());
-  try {
-    pair = hashObject->pairs[key];
-  }
-  catch (...) {
-    return newError("key not in hash");
-  }
-  return pair->value;
+    shared_ptr<Hash> hashObject = static_pointer_cast<Hash>(hash);
+    size_t key;
+    shared_ptr<HashPair> pair;
+    if (index->inspectType() == ObjectType.BOOLEAN_OBJ)
+        key = hashKey(static_pointer_cast<Boolean>(index));
+    else if (index->inspectType() == ObjectType.INTEGER_OBJ)
+        key = hashKey(static_pointer_cast<Integer>(index));
+    else if (index->inspectType() == ObjectType.STRING_OBJ)
+        key = hashKey(static_pointer_cast<String>(index));
+    else return newError("unusable as hash key: " + index->inspectType());
+    try {
+        pair = hashObject->pairs[key];
+    } catch (...) {
+        return newError("key not in hash");
+    }
+    return pair->value;
 }
-
 
 shared_ptr<Object> evalHashLiteral(shared_ptr<HashLiteral> expr, shared_ptr<Environment> env) {
-  unordered_map<size_t, shared_ptr<HashPair>> pairs;
-  size_t hashed;
-  for (pair<shared_ptr<Expression>, shared_ptr<Expression>> el : expr->pairs) {
-    shared_ptr<Object> key = evalNode(el.first, env);
-    if (isError(key))
-      return key;
-    // TODO: implement check for hashable key
-    shared_ptr<Object> val = evalNode(el.second, env);
-    if (isError(val))
-      return val;
+    unordered_map<size_t, shared_ptr<HashPair>> pairs;
+    size_t hashed;
+    for (pair<shared_ptr<Expression>, shared_ptr<Expression>> el : expr->pairs) {
+        shared_ptr<Object> key = evalNode(el.first, env);
+        if (isError(key)) return key;
+        // TODO: implement check for hashable key
+        shared_ptr<Object> val = evalNode(el.second, env);
+        if (isError(val)) return val;
 
-    if (key->inspectType() == ObjectType.INTEGER_OBJ)
-      hashed = hashKey(static_pointer_cast<Integer>(key));
-    else if (key->inspectType() == ObjectType.STRING_OBJ)
-      hashed = hashKey(static_pointer_cast<String>(key));
-    else if (key->inspectType() == ObjectType.BOOLEAN_OBJ)
-      hashed = hashKey(static_pointer_cast<Boolean>(key));
-    else
-      return newError("unusable as hash key: " + key->inspectType());
+        if (key->inspectType() == ObjectType.INTEGER_OBJ)
+            hashed = hashKey(static_pointer_cast<Integer>(key));
+        else if (key->inspectType() == ObjectType.STRING_OBJ)
+            hashed = hashKey(static_pointer_cast<String>(key));
+        else if (key->inspectType() == ObjectType.BOOLEAN_OBJ)
+            hashed = hashKey(static_pointer_cast<Boolean>(key));
+        else return newError("unusable as hash key: " + key->inspectType());
 
-    shared_ptr<HashPair> newh (new HashPair(key, val));
-    pairs[hashed] = newh;
-    env->gc.push_back(newh);
-  }
-  shared_ptr<Hash> hash (new Hash);
-  env->gc.push_back(hash);
-  hash->pairs = pairs;
-  return hash;
+        shared_ptr<HashPair> newh(new HashPair(key, val));
+        pairs[hashed] = newh;
+        env->gc.push_back(newh);
+    }
+    shared_ptr<Hash> hash(new Hash);
+    env->gc.push_back(hash);
+    hash->pairs = pairs;
+    return hash;
 }
-
 
 shared_ptr<Object> evalIdentifier(shared_ptr<IdentifierLiteral> node, shared_ptr<Environment> env) {
-  auto builtin_find = builtins.find(node->value);
-  if(builtin_find != builtins.end()) {
-    unique_ptr<Builtin> bi (new Builtin());
-    bi->builtin_type = builtin_find->second;
-    // env->gc.push_back(bi);
-    return bi;
-  }
-  
-  shared_ptr<Object> val = env->get(node->value);
-  if (val != nullptr)
-    return val;
+    auto builtin_find = builtins.find(node->value);
+    if (builtin_find != builtins.end()) {
+        unique_ptr<Builtin> bi(new Builtin());
+        bi->builtin_type = builtin_find->second;
+        // env->gc.push_back(bi);
+        return bi;
+    }
 
-  return newError("identifier not found: " + node->value);
-  
+    shared_ptr<Object> val = env->get(node->value);
+    if (val != nullptr) return val;
+
+    return newError("identifier not found: " + node->value);
 }
-
 
 shared_ptr<Object> evalIfExpression(shared_ptr<IfExpression> expr, shared_ptr<Environment> env) {
-  shared_ptr<Object> initCondition = evalNode(expr->condition, env);
-  if (isError(initCondition))
-    return initCondition;
+    shared_ptr<Object> initCondition = evalNode(expr->condition, env);
+    if (isError(initCondition)) return initCondition;
 
-  // if first if condition is true, eval consequence
-  if (isTruthy(initCondition))
-    return evalNode(expr->consequence, env);
-  else {
-    // if else-if present, iterate through to find true condition
-    for (int i = 0; i < expr->conditions.size(); i++) {
-      shared_ptr<Object> cond = evalNode(expr->conditions[i], env);
-      if (isError(cond))
-        return cond;
-      if (isTruthy(cond))
-        return evalNode(expr->alternatives[i], env);
+    // if first if condition is true, eval consequence
+    if (isTruthy(initCondition)) return evalNode(expr->consequence, env);
+    else {
+        // if else-if present, iterate through to find true condition
+        for (int i = 0; i < expr->conditions.size(); i++) {
+            shared_ptr<Object> cond = evalNode(expr->conditions[i], env);
+            if (isError(cond)) return cond;
+            if (isTruthy(cond)) return evalNode(expr->alternatives[i], env);
+        }
+        // if no else-ifs true/found, evaluate final else
+        if (expr->alternative != nullptr) return evalNode(expr->alternative, env);
+        else return nullptr;
     }
-    // if no else-ifs true/found, evaluate final else
-    if (expr->alternative != nullptr)
-      return evalNode(expr->alternative, env);
-    else
-      return nullptr;
-  }
 }
 
-
-shared_ptr<Object> evalIndexExpression(shared_ptr<Object> left, shared_ptr<Object> index, shared_ptr<Environment> env) {
-  if (left->inspectType() == ObjectType.ARRAY_OBJ && 
+shared_ptr<Object> evalIndexExpression(
+    shared_ptr<Object> left, shared_ptr<Object> index, shared_ptr<Environment> env
+) {
+    if (left->inspectType() == ObjectType.ARRAY_OBJ &&
         index->inspectType() == ObjectType.INTEGER_OBJ)
-    return evalArrayIndexExpression(left, index, env);
-  if (left->inspectType() == ObjectType.STRING_OBJ && 
+        return evalArrayIndexExpression(left, index, env);
+    if (left->inspectType() == ObjectType.STRING_OBJ &&
         index->inspectType() == ObjectType.INTEGER_OBJ)
-    return evalStringIndexExpression(left, index, env);
-  if (left->inspectType() == ObjectType.HASH_OBJ)
-    return evalHashIndexExpression(left, index);
-  else
-    return newError("index operator not supported: " + left->inspectType());
+        return evalStringIndexExpression(left, index, env);
+    if (left->inspectType() == ObjectType.HASH_OBJ) return evalHashIndexExpression(left, index);
+    else return newError("index operator not supported: " + left->inspectType());
 }
-
 
 shared_ptr<Object> evalInfixExpression(
-    string op, shared_ptr<Object> l, shared_ptr<Object> r,shared_ptr<Environment> env
-  ) {
-  if (l->type == INTEGER_OBJ && r->type == INTEGER_OBJ)
-    return evalIntegerInfixExpression(op, l, r, env);
-  else if (l->type == STRING_OBJ && r->type == STRING_OBJ)
-    return evalStringInfixExpression(op, l, r, env);
-  else if (op == "==")
-    return nativeToBoolean(l->inspectObject() == r->inspectObject());
-  else if (op == "!=")
-    return nativeToBoolean(l->inspectObject() != r->inspectObject());
-  else if (l->type !=  r->type) {
+    string op, shared_ptr<Object> l, shared_ptr<Object> r, shared_ptr<Environment> env
+) {
+    if (l->type == INTEGER_OBJ && r->type == INTEGER_OBJ)
+        return evalIntegerInfixExpression(op, l, r, env);
+    else if (l->type == STRING_OBJ && r->type == STRING_OBJ)
+        return evalStringInfixExpression(op, l, r, env);
+    else if (op == "==") return nativeToBoolean(l->inspectObject() == r->inspectObject());
+    else if (op == "!=") return nativeToBoolean(l->inspectObject() != r->inspectObject());
+    else if (l->type != r->type) {
+        ostringstream ss;
+        ss << "Type mismatch: " << l->inspectType() << op << r->inspectType();
+        return newError(ss.str());
+    }
     ostringstream ss;
-    ss << "Type mismatch: " << l->inspectType() << op << r->inspectType();
+    ss << "Unknown operator: " << l->inspectType() << op << r->inspectType();
     return newError(ss.str());
-  }
-  ostringstream ss;
-  ss << "Unknown operator: " << l->inspectType() << op << r->inspectType();
-  return newError(ss.str());
 }
-
 
 shared_ptr<Object> evalIntegerInfixExpression(
     string op, shared_ptr<Object> l, shared_ptr<Object> r, shared_ptr<Environment> env
-  ) {
-  int leftVal = static_pointer_cast<Integer>(l)->value;
-  int rightVal = static_pointer_cast<Integer>(r)->value;
+) {
+    int leftVal = static_pointer_cast<Integer>(l)->value;
+    int rightVal = static_pointer_cast<Integer>(r)->value;
 
-  if (op.length() > 2) {
-    ostringstream ss;
-    ss << "Unknown operator: " << leftVal << op << rightVal;
-    return newError(ss.str());
-  }
+    if (op.length() > 2) {
+        ostringstream ss;
+        ss << "Unknown operator: " << leftVal << op << rightVal;
+        return newError(ss.str());
+    }
 
-  switch (op[0]) {
-    case '+': {
-      shared_ptr<Integer> newi (new Integer(leftVal + rightVal));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    case '-': {
-      shared_ptr<Integer> newi (new Integer(leftVal - rightVal));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    case '*': {
-      shared_ptr<Integer> newi (new Integer(leftVal * rightVal));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    case '/': {
-      shared_ptr<Integer> newi (new Integer(leftVal / rightVal));
-      env->gc.push_back(newi);
-      return newi;
-    }
-    case '<':
-      return nativeToBoolean(leftVal < rightVal);
-    case '>':
-      return nativeToBoolean(leftVal > rightVal);
-    case '=': {
-      if (op[1] == '=')
-        return nativeToBoolean(leftVal == rightVal);
+    switch (op[0]) {
+        case '+':
+            {
+                shared_ptr<Integer> newi(new Integer(leftVal + rightVal));
+                env->gc.push_back(newi);
+                return newi;
+            }
+        case '-':
+            {
+                shared_ptr<Integer> newi(new Integer(leftVal - rightVal));
+                env->gc.push_back(newi);
+                return newi;
+            }
+        case '*':
+            {
+                shared_ptr<Integer> newi(new Integer(leftVal * rightVal));
+                env->gc.push_back(newi);
+                return newi;
+            }
+        case '/':
+            {
+                shared_ptr<Integer> newi(new Integer(leftVal / rightVal));
+                env->gc.push_back(newi);
+                return newi;
+            }
+        case '<':
+            return nativeToBoolean(leftVal < rightVal);
+        case '>':
+            return nativeToBoolean(leftVal > rightVal);
+        case '=':
+            {
+                if (op[1] == '=') return nativeToBoolean(leftVal == rightVal);
 
-      ostringstream ss;
-      ss << "Unknown operator: " << leftVal << op << rightVal;
-      return newError(ss.str());
-    }
-    case '!': {
-      if (op[1] == '=')
-        return nativeToBoolean(leftVal != rightVal);
+                ostringstream ss;
+                ss << "Unknown operator: " << leftVal << op << rightVal;
+                return newError(ss.str());
+            }
+        case '!':
+            {
+                if (op[1] == '=') return nativeToBoolean(leftVal != rightVal);
 
-      ostringstream ss;
-      ss << "Unknown operator: " << leftVal << op << rightVal;
-      return newError(ss.str());
+                ostringstream ss;
+                ss << "Unknown operator: " << leftVal << op << rightVal;
+                return newError(ss.str());
+            }
+        default:
+            ostringstream ss;
+            ss << "Unknown operator: " << leftVal << op << rightVal;
+            return newError(ss.str());
     }
-    default:
-      ostringstream ss;
-      ss << "Unknown operator: " << leftVal << op << rightVal;
-      return newError(ss.str());
-  }
 }
-
 
 shared_ptr<Object> evalLoop(shared_ptr<Loop> loop) {
-  //FIXME: loop body variable scope not limited; sets outer/global scope
-  shared_ptr<Object> cond = nullptr;
-  if (!(loop->loop_type == forLoop))
-    cond = evalNode(loop->condition, loop->env);
-  if (isError(cond)) return cond;
+    // FIXME: loop body variable scope not limited; sets outer/global scope
+    shared_ptr<Object> cond = nullptr;
+    if (!(loop->loop_type == forLoop)) cond = evalNode(loop->condition, loop->env);
+    if (isError(cond)) return cond;
 
-  shared_ptr<Boolean> b = static_pointer_cast<Boolean>(cond);
-  shared_ptr<Object> result = nullptr;
-  switch (loop->loop_type) {
-    case doLoop: {
-      do {
-        result = unpackLoopBody(loop);
-        cond = evalNode(loop->condition, loop->env);
-        b = static_pointer_cast<Boolean>(cond);
-      } while (b->value);
-      return result;
+    shared_ptr<Boolean> b = static_pointer_cast<Boolean>(cond);
+    shared_ptr<Object> result = nullptr;
+    switch (loop->loop_type) {
+        case doLoop:
+            {
+                do {
+                    result = unpackLoopBody(loop);
+                    cond = evalNode(loop->condition, loop->env);
+                    b = static_pointer_cast<Boolean>(cond);
+                } while (b->value);
+                return result;
+            }
+        case forLoop:
+            {
+                for (int i = loop->start; i < loop->end; i += loop->increment) {
+                    result = unpackLoopBody(loop);
+                    for (auto stmt : loop->statements)
+                        dynamic_pointer_cast<Integer>(loop->env->get(stmt->token.literal))->value +=
+                            loop->increment;
+                }
+                return result;
+            }
+        case whileLoop:
+            {
+                while (b->value) {
+                    result = unpackLoopBody(loop);
+                    cond = evalNode(loop->condition, loop->env);
+                    b = static_pointer_cast<Boolean>(cond);
+                }
+                return result;
+            }
     }
-    case forLoop: {
-      for (int i = loop->start; i < loop->end; i += loop->increment) {
-        result = unpackLoopBody(loop);
-        for (auto stmt : loop->statements)
-          dynamic_pointer_cast<Integer>(loop->env->get(stmt->token.literal))->value += loop->increment;
-      }
-      return result;
-    }
-    case whileLoop: {
-      while (b->value) {
-        result = unpackLoopBody(loop);
-        cond = evalNode(loop->condition, loop->env);
-        b = static_pointer_cast<Boolean>(cond);
-      }
-      return result;
-    }
-  }
-  return newError("Not a valid loop type.");
+    return newError("Not a valid loop type.");
 }
 
-
-shared_ptr<Object> evalMinusOperatorExpression(shared_ptr<Object> right, shared_ptr<Environment> env) {
-  if (right->type != INTEGER_OBJ) {
-    ostringstream ss;
-    ss << "Unknown operator: -" << right->inspectType();
-    return newError(ss.str());
-  }
-  shared_ptr<Integer> i = static_pointer_cast<Integer>(right);
-  shared_ptr<Integer> newi (new Integer(-i->value));
-  env->gc.push_back(newi);
-  shared_ptr<Object> newInt = static_pointer_cast<Integer>(newi);
-  return newInt;
+shared_ptr<Object>
+evalMinusOperatorExpression(shared_ptr<Object> right, shared_ptr<Environment> env) {
+    if (right->type != INTEGER_OBJ) {
+        ostringstream ss;
+        ss << "Unknown operator: -" << right->inspectType();
+        return newError(ss.str());
+    }
+    shared_ptr<Integer> i = static_pointer_cast<Integer>(right);
+    shared_ptr<Integer> newi(new Integer(-i->value));
+    env->gc.push_back(newi);
+    shared_ptr<Object> newInt = static_pointer_cast<Integer>(newi);
+    return newInt;
 }
-
 
 shared_ptr<Object> evalNode(shared_ptr<Node> node, shared_ptr<Environment> env = err_gc) {
-  if (env == nullptr)
-    env = err_gc;
-  if (node->nodetype == statement) {
-    shared_ptr<Statement> stmt = static_pointer_cast<Statement>(node);
-    return evalStatements(stmt, env);
-  }
-  else {
-    shared_ptr<Expression> expr = static_pointer_cast<Expression>(node);
-    return evalExpressions(expr, env);
-  }
-}
-
-
-shared_ptr<Object> evalPostfixExpression(string op, shared_ptr<Object> left, shared_ptr<Environment> env) {
-  if (left->type != INTEGER_OBJ)
-    return newError("Increment operation on non-integer object.");
-
-  shared_ptr<Integer> i = static_pointer_cast<Integer>(left);
-
-  if (op == "++") {
-    shared_ptr<Integer> newi (new Integer(i->value + 1));
-    env->gc.push_back(newi);
-    return newi;
-  }
-  else if (op == "--") {
-    shared_ptr<Integer> newi (new Integer(i->value - 1));
-    env->gc.push_back(newi);
-    return newi;
-  }
-  else return newError("not a valid postfix operation.");
-}
-
-
-shared_ptr<Object> evalPrefixExpression(string op, shared_ptr<Object> r, shared_ptr<Environment> env) {
-  switch(op[0]) {
-    case '!':
-      return evalBangOperatorExpression(r);
-    case '-':
-      return evalMinusOperatorExpression(r, env);
-    default:
-      ostringstream ss;
-      ss << "Unknown operator: " << op << r->inspectType();
-      return newError(ss.str());
-  }
-}
-
-
-shared_ptr<Object> evalStringIndexExpression(shared_ptr<Object> str, shared_ptr<Object> index, shared_ptr<Environment> env) {
-  shared_ptr<String> stringObject = static_pointer_cast<String>(str);
-  shared_ptr<Integer> intObject = static_pointer_cast<Integer>(index);
-  int idx = intObject->value;
-  int max = stringObject->value.length();
-  if (idx < 0) {
-    if (idx + max < 0) {
-      ostringstream ss;
-      ss << "index out of range.";
-      return newError(ss.str());
+    if (env == nullptr) env = err_gc;
+    if (node->nodetype == statement) {
+        shared_ptr<Statement> stmt = static_pointer_cast<Statement>(node);
+        return evalStatements(stmt, env);
+    } else {
+        shared_ptr<Expression> expr = static_pointer_cast<Expression>(node);
+        return evalExpressions(expr, env);
     }
-    string s(1, stringObject->value[idx + max]);
-    shared_ptr<String> news (new String(s));
+}
+
+shared_ptr<Object>
+evalPostfixExpression(string op, shared_ptr<Object> left, shared_ptr<Environment> env) {
+    if (left->type != INTEGER_OBJ) return newError("Increment operation on non-integer object.");
+
+    shared_ptr<Integer> i = static_pointer_cast<Integer>(left);
+
+    if (op == "++") {
+        shared_ptr<Integer> newi(new Integer(i->value + 1));
+        env->gc.push_back(newi);
+        return newi;
+    } else if (op == "--") {
+        shared_ptr<Integer> newi(new Integer(i->value - 1));
+        env->gc.push_back(newi);
+        return newi;
+    } else return newError("not a valid postfix operation.");
+}
+
+shared_ptr<Object>
+evalPrefixExpression(string op, shared_ptr<Object> r, shared_ptr<Environment> env) {
+    switch (op[0]) {
+        case '!':
+            return evalBangOperatorExpression(r);
+        case '-':
+            return evalMinusOperatorExpression(r, env);
+        default:
+            ostringstream ss;
+            ss << "Unknown operator: " << op << r->inspectType();
+            return newError(ss.str());
+    }
+}
+
+shared_ptr<Object> evalStringIndexExpression(
+    shared_ptr<Object> str, shared_ptr<Object> index, shared_ptr<Environment> env
+) {
+    shared_ptr<String> stringObject = static_pointer_cast<String>(str);
+    shared_ptr<Integer> intObject = static_pointer_cast<Integer>(index);
+    int idx = intObject->value;
+    int max = stringObject->value.length();
+    if (idx < 0) {
+        if (idx + max < 0) {
+            ostringstream ss;
+            ss << "index out of range.";
+            return newError(ss.str());
+        }
+        string s(1, stringObject->value[idx + max]);
+        shared_ptr<String> news(new String(s));
+        env->gc.push_back(news);
+        return news;
+    }
+    if (idx > max - 1) {
+        ostringstream ss;
+        ss << "index out of range.";
+        return newError(ss.str());
+    }
+    string s(1, stringObject->value[idx]);
+    shared_ptr<String> news(new String(s));
     env->gc.push_back(news);
     return news;
-  }
-  if (idx > max - 1) {
-    ostringstream ss;
-    ss << "index out of range.";
-    return newError(ss.str());
-  }
-  string s(1, stringObject->value[idx]);
-  shared_ptr<String> news (new String(s));
-  env->gc.push_back(news);
-  return news;
 }
 
-
-shared_ptr<Object> evalStatements(shared_ptr<Statement> stmt, shared_ptr<Environment> env = nullptr) {
-  switch (stmt->type) {
-    case assignmentExpressionStatement: {
-      //FIXME: string += int returns only int
-      shared_ptr<AssignmentExpressionStatement> ae = static_pointer_cast<AssignmentExpressionStatement>(stmt);
-      shared_ptr<Object> val = evalNode(ae->value, env);
-      if (isError(val))
-        return val;
-      shared_ptr<Object> oldVal = env->get(ae->name->value);
-      if (val->type != oldVal->type)
-        return newError("Cannot assign " + oldVal->inspectType() + " and " + val->inspectType());
-      shared_ptr<Object> newVal = evalAssignmentExpression(ae->_operator, oldVal, val, env);
-      env->set(ae->name->value, newVal);
-      break;
+shared_ptr<Object>
+evalStatements(shared_ptr<Statement> stmt, shared_ptr<Environment> env = nullptr) {
+    switch (stmt->type) {
+        case assignmentExpressionStatement:
+            {
+                // FIXME: string += int returns only int
+                shared_ptr<AssignmentExpressionStatement> ae =
+                    static_pointer_cast<AssignmentExpressionStatement>(stmt);
+                shared_ptr<Object> val = evalNode(ae->value, env);
+                if (isError(val)) return val;
+                shared_ptr<Object> oldVal = env->get(ae->name->value);
+                if (val->type != oldVal->type)
+                    return newError(
+                        "Cannot assign " + oldVal->inspectType() + " and " + val->inspectType()
+                    );
+                shared_ptr<Object> newVal =
+                    evalAssignmentExpression(ae->_operator, oldVal, val, env);
+                env->set(ae->name->value, newVal);
+                break;
+            }
+        case blockStatement:
+            {
+                shared_ptr<BlockStatement> bs = static_pointer_cast<BlockStatement>(stmt);
+                for (auto stmt : bs->statements) {
+                    shared_ptr<Object> result = evalNode(stmt, env);
+                    if (result != nullptr && result->type == RETURN_OBJ) return result;
+                }
+                return nullptr;
+            }
+        case expressionStatement:
+            {
+                shared_ptr<ExpressionStatement> es = static_pointer_cast<ExpressionStatement>(stmt);
+                return evalNode(es->expression, env);
+            }
+        case functionStatement:
+            {
+                shared_ptr<FunctionStatement> fs = static_pointer_cast<FunctionStatement>(stmt);
+                shared_ptr<Function> newf(new Function(fs->parameters, fs->body, env));
+                env->set(fs->name->value, newf);
+                return newf;
+            }
+        case identifierStatement:
+            {
+                break;
+            }
+        case letStatement:
+            {
+                shared_ptr<LetStatement> ls = static_pointer_cast<LetStatement>(stmt);
+                shared_ptr<Object> val = evalNode(ls->value, env);
+                if (isError(val)) return val;
+                env->set(ls->name->value, val);
+                break;
+            }
+        case returnStatement:
+            {
+                shared_ptr<ReturnStatement> rs = static_pointer_cast<ReturnStatement>(stmt);
+                shared_ptr<Object> val = evalNode(rs->returnValue, env);
+                if (isError(val)) return val;
+                shared_ptr<ReturnValue> newr(new ReturnValue(val));
+                env->gc.push_back(newr);
+                return newr;
+            }
     }
-    case blockStatement: {
-      shared_ptr<BlockStatement> bs = static_pointer_cast<BlockStatement>(stmt);
-      for (auto stmt : bs->statements) {
-        shared_ptr<Object> result = evalNode(stmt, env);
-        if (result != nullptr && result->type == RETURN_OBJ)
-          return result;
-      }
-      return nullptr;
-    }
-    case expressionStatement: {
-      shared_ptr<ExpressionStatement> es = static_pointer_cast<ExpressionStatement>(stmt);
-      return evalNode(es->expression, env);
-    }
-    case functionStatement: {
-      shared_ptr<FunctionStatement> fs = static_pointer_cast<FunctionStatement>(stmt);
-      shared_ptr<Function> newf (new Function(fs->parameters, fs->body, env));
-      env->set(fs->name->value, newf);
-      return newf;
-    }
-    case identifierStatement:{
-      break;
-    }
-    case letStatement: {
-      shared_ptr<LetStatement> ls = static_pointer_cast<LetStatement>(stmt);
-      shared_ptr<Object> val = evalNode(ls->value, env);
-      if (isError(val))
-        return val;
-      env->set(ls->name->value, val);
-      break;
-    }
-    case returnStatement: {
-      shared_ptr<ReturnStatement> rs = static_pointer_cast<ReturnStatement>(stmt);
-      shared_ptr<Object> val = evalNode(rs->returnValue, env);
-      if (isError(val))
-        return val;
-      shared_ptr<ReturnValue> newr (new ReturnValue(val));
-      env->gc.push_back(newr);
-      return newr;
-    }
-  }
-  return nullptr;
+    return nullptr;
 }
 
-
-shared_ptr<Object> evalStringInfixExpression(string op, shared_ptr<Object> l, shared_ptr<Object> r, shared_ptr<Environment> env) {
-  if (op[0] != '+')
-    return newError("unknown operator: " + l->inspectType() + " " + op + " " + r->inspectType());
-  shared_ptr<String> nl = static_pointer_cast<String>(l);
-  shared_ptr<String> nr = static_pointer_cast<String>(r);
-  shared_ptr<String> news (new String(nl->value + nr->value));
-  env->gc.push_back(news);
-  return news;
+shared_ptr<Object> evalStringInfixExpression(
+    string op, shared_ptr<Object> l, shared_ptr<Object> r, shared_ptr<Environment> env
+) {
+    if (op[0] != '+')
+        return newError(
+            "unknown operator: " + l->inspectType() + " " + op + " " + r->inspectType()
+        );
+    shared_ptr<String> nl = static_pointer_cast<String>(l);
+    shared_ptr<String> nr = static_pointer_cast<String>(r);
+    shared_ptr<String> news(new String(nl->value + nr->value));
+    env->gc.push_back(news);
+    return news;
 }
-
 
 shared_ptr<Environment> extendFunction(shared_ptr<Function> fn, vector<shared_ptr<Object>> args) {
-  shared_ptr<Environment> env (new Environment(fn->env));
-  for (int i = 0; i < fn->parameters.size(); i++) {
-    env->set(fn->parameters[i]->value, args[i]);
-  }
-  return env;
+    shared_ptr<Environment> env(new Environment(fn->env));
+    for (int i = 0; i < fn->parameters.size(); i++) {
+        env->set(fn->parameters[i]->value, args[i]);
+    }
+    return env;
 }
 
+size_t hashKey(shared_ptr<Boolean> b) { return b->value ? 1 : 0; }
 
-size_t hashKey(shared_ptr<Boolean> b) {
-  return b->value ? 1 : 0;
-}
+size_t hashKey(shared_ptr<Integer> i) { return i->value; }
 
-
-size_t hashKey(shared_ptr<Integer> i) {
-  return i->value;
-}
-
-size_t hashKey(shared_ptr<String> s) {
-  return hash<string>{}(s->value);
-}
-
+size_t hashKey(shared_ptr<String> s) { return hash<string>{}(s->value); }
 
 bool isError(shared_ptr<Object> obj) {
-  if (obj != nullptr) {
-    return obj->type == ERROR_OBJ;
-  }
-  return false;
+    if (obj != nullptr) {
+        return obj->type == ERROR_OBJ;
+    }
+    return false;
 }
-
 
 bool isTruthy(shared_ptr<Object> obj) {
-  switch(obj->type) {
-    case BOOLEAN_TRUE:
-      return true;
-    case BOOLEAN_FALSE:
-      return false;
-    case NULL_OBJ:
-      return false;
-    default:
-      return true;
-  }
+    switch (obj->type) {
+        case BOOLEAN_TRUE:
+            return true;
+        case BOOLEAN_FALSE:
+            return false;
+        case NULL_OBJ:
+            return false;
+        default:
+            return true;
+    }
 }
-
 
 shared_ptr<Boolean> nativeToBoolean(bool input) {
-  if (input)
-    return static_pointer_cast<Boolean>(TRUE_BOOL);
-  return static_pointer_cast<Boolean>(FALSE_BOOL);
+    if (input) return static_pointer_cast<Boolean>(TRUE_BOOL);
+    return static_pointer_cast<Boolean>(FALSE_BOOL);
 }
-
 
 shared_ptr<Object> newError(string msg) {
-  shared_ptr<Object> err (new Error(msg));
-  err_gc->gc.push_back(err);
-  return err;
+    shared_ptr<Object> err(new Error(msg));
+    err_gc->gc.push_back(err);
+    return err;
 }
-
 
 shared_ptr<Object> unpackLoopBody(shared_ptr<Loop> loop) {
-  for (auto stmt : loop->body->statements) {
-    shared_ptr<Object> result = evalNode(stmt, loop->env);
-    if (result != nullptr && result->type == RETURN_OBJ)
-      return result;
-  }
-  return nullptr;
+    for (auto stmt : loop->body->statements) {
+        shared_ptr<Object> result = evalNode(stmt, loop->env);
+        if (result != nullptr && result->type == RETURN_OBJ) return result;
+    }
+    return nullptr;
 }
 
-
 shared_ptr<Object> unwrapReturnValue(shared_ptr<Object> evaluated) {
-  if (evaluated->inspectType() == ObjectType.RETURN_OBJ) {
-    shared_ptr<ReturnValue> obj = dynamic_pointer_cast<ReturnValue>(evaluated);
-    return obj->value;
-  }
-  return evaluated;
+    if (evaluated->inspectType() == ObjectType.RETURN_OBJ) {
+        shared_ptr<ReturnValue> obj = dynamic_pointer_cast<ReturnValue>(evaluated);
+        return obj->value;
+    }
+    return evaluated;
 }

--- a/src/evaluator.hpp
+++ b/src/evaluator.hpp
@@ -3,27 +3,36 @@
 
 using namespace std;
 
-shared_ptr<Object> applyFunction(shared_ptr<Object>, vector<shared_ptr<Object>>, shared_ptr<Environment>);
-shared_ptr<Object> evalArrayIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
-shared_ptr<Object> evalAssignmentExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    applyFunction(shared_ptr<Object>, vector<shared_ptr<Object>>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalArrayIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalAssignmentExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Object> evalBangOperatorExpression(shared_ptr<Object>);
-vector<shared_ptr<Object>> evalCallExpressions(vector<shared_ptr<Expression>> expr, shared_ptr<Environment>);
+vector<shared_ptr<Object>>
+evalCallExpressions(vector<shared_ptr<Expression>> expr, shared_ptr<Environment>);
 shared_ptr<Object> evalExpressions(shared_ptr<Expression>, shared_ptr<Environment>);
 shared_ptr<Object> evalHashIndexExpression(shared_ptr<Object>, shared_ptr<Object>);
 shared_ptr<Object> evalHashLiteral(shared_ptr<HashLiteral>, shared_ptr<Environment>);
 shared_ptr<Object> evalIdentifier(shared_ptr<IdentifierLiteral>, shared_ptr<Environment>);
 shared_ptr<Object> evalIfExpression(shared_ptr<IfExpression>, shared_ptr<Environment>);
-shared_ptr<Object> evalIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
-shared_ptr<Object> evalInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
-shared_ptr<Object> evalIntegerInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalIntegerInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Object> evalLoop(shared_ptr<Loop>);
 shared_ptr<Object> evalMinusOperatorExpression(shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Object> evalNode(shared_ptr<Node>, shared_ptr<Environment>);
 shared_ptr<Object> evalPostfixExpression(string, shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Object> evalPrefixExpression(string, shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Object> evalStatements(shared_ptr<Statement>, shared_ptr<Environment>);
-shared_ptr<Object> evalStringIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
-shared_ptr<Object> evalStringInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalStringIndexExpression(shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
+shared_ptr<Object>
+    evalStringInfixExpression(string, shared_ptr<Object>, shared_ptr<Object>, shared_ptr<Environment>);
 shared_ptr<Environment> extendFunction(shared_ptr<Function>, vector<shared_ptr<Object>>);
 size_t hashKey(shared_ptr<Integer>);
 size_t hashKey(shared_ptr<Boolean>);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,296 +1,269 @@
-#include <ostream>
-#include <algorithm>
 #include "lexer.hpp"
+
+#include <algorithm>
+#include <ostream>
 
 using namespace std;
 
-
 Lexer::Lexer(string input) {
-  this->input = input;
-  this->readChar();
+    this->input = input;
+    this->readChar();
 }
-
 
 Token Lexer::nextToken() {
-  Token tok;
-  this->skipWhitespace();
+    Token tok;
+    this->skipWhitespace();
 
-  switch (this->ch) {
-    case '=':
-      if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "==";
-        tok.type = lookupIdentifier(tok.literal);
-        break;
-      }
-      tok = newToken(TokenType.ASSIGN, this->ch);
-      break;
-    case '+':
-      if (this->peekChar() == '+') {
-        this->readChar();
-        tok.literal = "++";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "+=";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else {
-        tok = newToken(TokenType.PLUS, this->ch);
-      }
-      break;
-    case '-':
-      if (this->peekChar() == '-') {
-        this->readChar();
-        tok.literal = "--";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "-=";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else {
-        tok = newToken(TokenType.MINUS, this->ch);
-      }
-      break;
-    case '*':
-      if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "*=";
-        tok.type = lookupIdentifier(tok.literal);
-        break;
-      }
-      tok = newToken(TokenType.ASTERISK, this->ch);
-      break;
-    case '/':
-      if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "/=";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else if (this->peekChar() == '/') {
-        this->readChar();
-        string comment = this->readComment();
-        tok.type = TokenType.COMMENT;
-        tok.literal = comment;
-      }
-      else if (this->peekChar() == '*') {
-        this->readChar();
-        string comment = this->readBlockComment();
-        tok.type = TokenType.BLOCK_COMMENT;
-        tok.literal = comment;
-      }
-      else {
-        tok = newToken(TokenType.SLASH, this->ch);
-      }
-      break;
-    case ',':
-      tok = newToken(TokenType.COMMA, this->ch);
-      break;
-    case '.':
-      tok = newToken(TokenType.PERIOD, this->ch);
-      break;
-    case ';':
-      tok = newToken(TokenType.SEMICOLON, this->ch);
-      break;
-    case ':':
-      tok = newToken(TokenType.COLON, this->ch);
-      break;
-    case '!':
-      if (this->peekChar() == '=') {
-        this->readChar();
-        tok.literal = "!=";
-        tok.type = lookupIdentifier(tok.literal);
-      }
-      else {
-        tok = newToken(TokenType.BANG, this->ch);
-      }
-      break;
-    case '(':
-      tok = newToken(TokenType.LPAREN, this->ch);
-      break;
-    case ')':
-      tok = newToken(TokenType.RPAREN, this->ch);
-      break;
-    case '{':
-      tok = newToken(TokenType.LBRACE, this->ch);
-      break;
-    case '}':
-      tok = newToken(TokenType.RBRACE, this->ch);
-      break;
-    case '[':
-      tok = newToken(TokenType.LBRACKET, this->ch);
-      break;
-    case ']':
-      tok = newToken(TokenType.RBRACKET, this->ch);
-      break;
-    case '<':
-      tok = newToken(TokenType.LT, this->ch);
-      break;
-    case '>':
-      tok = newToken(TokenType.GT, this->ch);
-      break;
-    case '\0':
-      tok.literal = {};
-      tok.type = TokenType._EOF;
-      break;
-    case '\"': {
-      this->readChar();
-      string str = this->readString();
-      tok.literal = str;
-      tok.type = TokenType._STRING;
-      break;
+    switch (this->ch) {
+        case '=':
+            if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "==";
+                tok.type = lookupIdentifier(tok.literal);
+                break;
+            }
+            tok = newToken(TokenType.ASSIGN, this->ch);
+            break;
+        case '+':
+            if (this->peekChar() == '+') {
+                this->readChar();
+                tok.literal = "++";
+                tok.type = lookupIdentifier(tok.literal);
+            } else if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "+=";
+                tok.type = lookupIdentifier(tok.literal);
+            } else {
+                tok = newToken(TokenType.PLUS, this->ch);
+            }
+            break;
+        case '-':
+            if (this->peekChar() == '-') {
+                this->readChar();
+                tok.literal = "--";
+                tok.type = lookupIdentifier(tok.literal);
+            } else if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "-=";
+                tok.type = lookupIdentifier(tok.literal);
+            } else {
+                tok = newToken(TokenType.MINUS, this->ch);
+            }
+            break;
+        case '*':
+            if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "*=";
+                tok.type = lookupIdentifier(tok.literal);
+                break;
+            }
+            tok = newToken(TokenType.ASTERISK, this->ch);
+            break;
+        case '/':
+            if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "/=";
+                tok.type = lookupIdentifier(tok.literal);
+            } else if (this->peekChar() == '/') {
+                this->readChar();
+                string comment = this->readComment();
+                tok.type = TokenType.COMMENT;
+                tok.literal = comment;
+            } else if (this->peekChar() == '*') {
+                this->readChar();
+                string comment = this->readBlockComment();
+                tok.type = TokenType.BLOCK_COMMENT;
+                tok.literal = comment;
+            } else {
+                tok = newToken(TokenType.SLASH, this->ch);
+            }
+            break;
+        case ',':
+            tok = newToken(TokenType.COMMA, this->ch);
+            break;
+        case '.':
+            tok = newToken(TokenType.PERIOD, this->ch);
+            break;
+        case ';':
+            tok = newToken(TokenType.SEMICOLON, this->ch);
+            break;
+        case ':':
+            tok = newToken(TokenType.COLON, this->ch);
+            break;
+        case '!':
+            if (this->peekChar() == '=') {
+                this->readChar();
+                tok.literal = "!=";
+                tok.type = lookupIdentifier(tok.literal);
+            } else {
+                tok = newToken(TokenType.BANG, this->ch);
+            }
+            break;
+        case '(':
+            tok = newToken(TokenType.LPAREN, this->ch);
+            break;
+        case ')':
+            tok = newToken(TokenType.RPAREN, this->ch);
+            break;
+        case '{':
+            tok = newToken(TokenType.LBRACE, this->ch);
+            break;
+        case '}':
+            tok = newToken(TokenType.RBRACE, this->ch);
+            break;
+        case '[':
+            tok = newToken(TokenType.LBRACKET, this->ch);
+            break;
+        case ']':
+            tok = newToken(TokenType.RBRACKET, this->ch);
+            break;
+        case '<':
+            tok = newToken(TokenType.LT, this->ch);
+            break;
+        case '>':
+            tok = newToken(TokenType.GT, this->ch);
+            break;
+        case '\0':
+            tok.literal = {};
+            tok.type = TokenType._EOF;
+            break;
+        case '\"':
+            {
+                this->readChar();
+                string str = this->readString();
+                tok.literal = str;
+                tok.type = TokenType._STRING;
+                break;
+            }
+        case '\'':
+            tok = newToken(TokenType.APOSTROPHE, this->ch);
+            break;
+        case '\n':
+            tok = newToken(TokenType.NEWLINE, this->ch);
+            break;
+        default:
+            if (isalpha(this->ch) || this->ch == '_') {
+                tok.literal = this->readIdentifier();
+                tok.type = lookupIdentifier(tok.literal);
+                return tok;
+            } else if (isdigit(this->ch)) {
+                tok = this->evaluateNumber();
+                return tok;
+            } else {
+                tok = newToken(TokenType.ILLEGAL, this->ch);
+                return tok;
+            }
     }
-    case '\'':
-      tok = newToken(TokenType.APOSTROPHE, this->ch);
-      break;
-    case '\n':
-      tok = newToken(TokenType.NEWLINE, this->ch);
-      break;
-    default:
-      if (isalpha(this->ch) || this->ch == '_') {
-        tok.literal = this->readIdentifier();
-        tok.type = lookupIdentifier(tok.literal);
-        return tok;
-      }
-      else if (isdigit(this->ch)) {
-        tok = this->evaluateNumber();
-        return tok;
-      }
-      else {
-        tok = newToken(TokenType.ILLEGAL, this->ch);
-        return tok;
-      }
-  }
-  this->readChar();
-  return tok;
+    this->readChar();
+    return tok;
 }
-
 
 Token Lexer::evaluateNumber() {
-  Token tok;
-  string result = this->readNumber();
-  tok.literal = result;
-  // if number has decimal
-  if (result.find('.') != string::npos) {
-    int c = count(result.begin(), result.end(), '.');
-    // if multiple decimals, illegal
-    if (c > 1) {
-      tok.type = TokenType.ILLEGAL;
-      return tok;
+    Token tok;
+    string result = this->readNumber();
+    tok.literal = result;
+    // if number has decimal
+    if (result.find('.') != string::npos) {
+        int c = count(result.begin(), result.end(), '.');
+        // if multiple decimals, illegal
+        if (c > 1) {
+            tok.type = TokenType.ILLEGAL;
+            return tok;
+        }
+        tok.type = TokenType.FLOAT;
+        return tok;
+    } else {
+        tok.type = TokenType.INT;
+        return tok;
     }
-    tok.type = TokenType.FLOAT;
-    return tok;
-  }
-  else {
-      tok.type = TokenType.INT;
-      return tok;
-  }
 }
-
 
 char Lexer::peekChar() {
-  if (this->readPosition > this->input.length()) {
-    return '\0';
-  }
-  else {
-    return this->input[this->readPosition];
-  }
+    if (this->readPosition > this->input.length()) {
+        return '\0';
+    } else {
+        return this->input[this->readPosition];
+    }
 }
-
 
 string Lexer::readBlockComment() {
-  int position = this->position + 1;
-  while (this->ch != '\0') {
-    if (this->ch == '*' && this->peekChar() == '/') {
-      this->readChar();
-      break;
+    int position = this->position + 1;
+    while (this->ch != '\0') {
+        if (this->ch == '*' && this->peekChar() == '/') {
+            this->readChar();
+            break;
+        }
+        this->readChar();
     }
-    this->readChar();
-  }
-  int diff = this->position - position;
-  string result = this->input.substr(position, diff - 1);
-  return result;
+    int diff = this->position - position;
+    string result = this->input.substr(position, diff - 1);
+    return result;
 }
-
 
 void Lexer::readChar() {
-  if (this->readPosition > this->input.length()) {
-    this->ch = '\0';
-    return;
-  }
-  else {
-    this->ch = this->input[this->readPosition];
-  }
-  this->position = this->readPosition;
-  this->readPosition += 1;
+    if (this->readPosition > this->input.length()) {
+        this->ch = '\0';
+        return;
+    } else {
+        this->ch = this->input[this->readPosition];
+    }
+    this->position = this->readPosition;
+    this->readPosition += 1;
 }
-
 
 string Lexer::readComment() {
-  int position = this->position + 1;
-  while (this->ch != '\0' && this->ch != '\n')
-    this->readChar();
-  int diff = this->position - position;
-  string result = this->input.substr(position, diff + 2);
-  return result;
+    int position = this->position + 1;
+    while (this->ch != '\0' && this->ch != '\n')
+        this->readChar();
+    int diff = this->position - position;
+    string result = this->input.substr(position, diff + 2);
+    return result;
 }
-
 
 string Lexer::readIdentifier() {
-  int position = this->position;
-  while (isalpha(this->ch) || this->ch == '_')
-    this->readChar();
-  int diff = this->position - position;
-  string result = this->input.substr(position, diff);
-  return result;
+    int position = this->position;
+    while (isalpha(this->ch) || this->ch == '_')
+        this->readChar();
+    int diff = this->position - position;
+    string result = this->input.substr(position, diff);
+    return result;
 }
-
 
 string Lexer::readNumber() {
-  int position = this->position;
-  while (isdigit(this->ch) || this->ch == '.')
-    this->readChar();
-  int diff = this->position - position;
-  string result = this->input.substr(position, diff);
-  return result;
+    int position = this->position;
+    while (isdigit(this->ch) || this->ch == '.')
+        this->readChar();
+    int diff = this->position - position;
+    string result = this->input.substr(position, diff);
+    return result;
 }
-
 
 string Lexer::readString() {
-  int position = this->position;
-  while(this->ch != '\"' && this->ch != '\0')
-    this->readChar();
-  int diff = this->position - position;
-  string result = this->input.substr(position, diff);
-  return result;
+    int position = this->position;
+    while (this->ch != '\"' && this->ch != '\0')
+        this->readChar();
+    int diff = this->position - position;
+    string result = this->input.substr(position, diff);
+    return result;
 }
-
 
 void Lexer::skipWhitespace() {
-  while (this->ch == ' ' || this->ch == '\t' || this->ch == '\n' || this->ch == '\r') 
-  {
-    this->readChar();
-  }
+    while (this->ch == ' ' || this->ch == '\t' || this->ch == '\n' || this->ch == '\r') {
+        this->readChar();
+    }
 }
-
 
 string lookupIdentifier(string ident) {
-  try {
-    return keywords.at(ident);
-  } 
-  catch (const out_of_range&) {
-    return TokenType.IDENT;
-  }
+    try {
+        return keywords.at(ident);
+    } catch (const out_of_range&) {
+        return TokenType.IDENT;
+    }
 }
-
 
 Token newToken(string type, char ch) {
-  // converting char to string
-  string str(1, ch);
-  Token tok = {type, str};
-  return tok;
+    // converting char to string
+    string str(1, ch);
+    Token tok = {type, str};
+    return tok;
 }
-

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,7 +1,6 @@
 #pragma once
-#include "token.hpp"
 #include "memory"
-
+#include "token.hpp"
 
 class Lexer {
   public:
@@ -11,6 +10,7 @@ class Lexer {
     std::string input;
 
     Token nextToken();
+
   private:
     char ch = input[0];
     int position = 0;
@@ -31,4 +31,3 @@ class Lexer {
 
 std::string lookupIdentifier(std::string);
 Token newToken(std::string, char);
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,28 +1,29 @@
 #include "object.hpp"
+
 #include <iostream>
 
 // using namespace std;
 void start(string, shared_ptr<Environment>);
 
 int main() {
-  system("clear");
-  string input;
-  shared_ptr<Environment> env (new Environment);
+    system("clear");
+    string input;
+    shared_ptr<Environment> env(new Environment);
 
-  while (true) {
-  start:
-    cout << ">> ";
-    getline(cin, input);
-    if (input == "quit") {
-      system("clear");
-      env->gc.clear();
-      env->store.clear();
-      return 0;
+    while (true) {
+    start:
+        cout << ">> ";
+        getline(cin, input);
+        if (input == "quit") {
+            system("clear");
+            env->gc.clear();
+            env->store.clear();
+            return 0;
+        }
+        if (input == "clear") {
+            system("clear");
+            goto start;
+        }
+        start(input, env);
     }
-    if (input == "clear") {
-      system("clear");
-      goto start;
-    }
-    start(input, env);
-  }
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,232 +1,175 @@
-# include "object.hpp"
+#include "object.hpp"
 
 using namespace std;
-
 
 Object::Object() { this->type = OBJECT_OBJ; };
 
 Array::Array(vector<shared_ptr<Object>> el) {
-  this->elements = el;
-  this->type = ARRAY_OBJ;
+    this->elements = el;
+    this->type = ARRAY_OBJ;
 }
 
-
 Boolean::Boolean(bool b) {
-  this->value = b;
-  if (b) { this->type = BOOLEAN_TRUE; }
-  else { this->type = BOOLEAN_FALSE; }
+    this->value = b;
+    if (b) this->type = BOOLEAN_TRUE;
+    else this->type = BOOLEAN_FALSE;
 }
 
 Environment::Environment(shared_ptr<Environment> env) {
-  if (env == nullptr) { this->outer = nullptr; }
-  else this->outer = env;
+    if (env == nullptr) this->outer = nullptr;
+    else this->outer = env;
 }
 
 Environment::~Environment() {
-  this->gc.clear();
-  this->store.clear();
+    this->gc.clear();
+    this->store.clear();
 }
 
 Error::Error(string msg) {
-  this->message = msg;
-  this->type = ERROR_OBJ;
+    this->message = msg;
+    this->type = ERROR_OBJ;
 }
 
 Float::Float(float fl) {
-  this->value = fl;
-  this->type = FLOAT_OBJ;
+    this->value = fl;
+    this->type = FLOAT_OBJ;
 }
 
 Function::Function(
-    vector<shared_ptr<IdentifierLiteral>> params, 
-    shared_ptr<BlockStatement> body, 
+    vector<shared_ptr<IdentifierLiteral>> params, shared_ptr<BlockStatement> body,
     shared_ptr<Environment> env
-  ) {
-  this->type = FUNCTION_OBJ;
-  this->parameters = params;
-  this->body = body;
-  this->env = env;
-  this->function_type = standardFunction;
+) {
+    this->type = FUNCTION_OBJ;
+    this->parameters = params;
+    this->body = body;
+    this->env = env;
+    this->function_type = standardFunction;
 }
-
 
 HashPair::HashPair(shared_ptr<Object> key, shared_ptr<Object> val) {
-  this->key = key;
-  this->value = val;
+    this->key = key;
+    this->value = val;
 }
 
-
 Integer::Integer(int val) {
-  this->value = val;
-  this->type = INTEGER_OBJ;
+    this->value = val;
+    this->type = INTEGER_OBJ;
 }
 
 Loop::Loop(int loop, shared_ptr<BlockStatement> body, shared_ptr<Environment> env) {
-  this->loop_type = loop;
-  this->body = body;
-  this->env = env;
+    this->loop_type = loop;
+    this->body = body;
+    this->env = env;
 }
 
 Null::Null() { this->type = NULL_OBJ; }
 
 ReturnValue::ReturnValue(shared_ptr<Object> obj) {
-  this->value = obj;
-  this->type = RETURN_OBJ;
+    this->value = obj;
+    this->type = RETURN_OBJ;
 }
 
 String::String(string str) {
-  this->value = str;
-  this->type = STRING_OBJ;
+    this->value = str;
+    this->type = STRING_OBJ;
 }
-
 
 /**********
-  Methods 
+  Methods
 ***********/
 
-string Object::inspectType() {
-  return ObjectType.OBJECT_OBJ;
-}
+string Object::inspectType() { return ObjectType.OBJECT_OBJ; }
 
-string Object::inspectObject() {
-  return "Object";
-}
+string Object::inspectObject() { return "Object"; }
 
-
-string Array::inspectType() {
-  return ObjectType.ARRAY_OBJ;
-}
+string Array::inspectType() { return ObjectType.ARRAY_OBJ; }
 
 string Array::inspectObject() {
-  ostringstream ss;
-  vector<string> elements;
-  for (auto el : this->elements)
-    elements.push_back(el->inspectObject());
-  ss << "[";
-  for (auto el : elements)
-    ss << el << ", ";
-  ss << "]";
-  return ss.str();
+    ostringstream ss;
+    vector<string> elements;
+    for (auto el : this->elements)
+        elements.push_back(el->inspectObject());
+    ss << "[";
+    for (auto el : elements)
+        ss << el << ", ";
+    ss << "]";
+    return ss.str();
 }
 
+string Boolean::inspectType() { return ObjectType.BOOLEAN_OBJ; }
 
-string Boolean::inspectType() {
-  return ObjectType.BOOLEAN_OBJ;
-}
-
-string Boolean::inspectObject() {
-  return this->value ? "true" : "false";
-}
-
+string Boolean::inspectObject() { return this->value ? "true" : "false"; }
 
 shared_ptr<Object> Environment::get(string name) {
-  try { 
-    shared_ptr<Object> res = this->store[name]; 
-    return res;
-  }
-  catch (...) {
-    if (this->outer != nullptr) {
-      try {
-        this->outer->get(name);
-      }
-      catch (...) { return nullptr; }
+    try {
+        shared_ptr<Object> res = this->store[name];
+        return res;
+    } catch (...) {
+        if (this->outer != nullptr) {
+            try {
+                this->outer->get(name);
+            } catch (...) {
+                return nullptr;
+            }
+        }
+        return nullptr;
     }
-    return nullptr; 
-  }
 }
 
 shared_ptr<Object> Environment::set(string name, shared_ptr<Object> val) {
-  this->store[name] = val;
-  return val;
+    this->store[name] = val;
+    return val;
 }
 
+string Error::inspectType() { return ObjectType.ERROR_OBJ; }
 
-string Error::inspectType() {
-  return ObjectType.ERROR_OBJ;
-}
+string Error::inspectObject() { return "ERROR: " + this->message; }
 
-string Error::inspectObject() {
-  return "ERROR: " + this->message;
-}
+string Float::inspectType() { return ObjectType.FLOAT_OBJ; }
 
+string Float::inspectObject() { return to_string(this->value); }
 
-string Float::inspectType() {
-  return ObjectType.FLOAT_OBJ;
-}
-
-string Float::inspectObject() {
-  return to_string(this->value);
-}
-
-
-string Function::inspectType() {
-  return ObjectType.FUNCTION_OBJ;
-}
+string Function::inspectType() { return ObjectType.FUNCTION_OBJ; }
 
 string Function::inspectObject() {
-  vector<string> params{};
+    vector<string> params{};
 
-  for (auto param : this->parameters)
-    params.push_back(param->printString());
+    for (auto param : this->parameters)
+        params.push_back(param->printString());
 
-  ostringstream ss;
-  for (string param : params) {
-    ss << "fn(" << param << ", ) {\n" << 
-      this->body->printString() << "\n}\n";
-  }
-  return ss.str();
+    ostringstream ss;
+    for (string param : params)
+        ss << "fn(" << param << ", ) {\n" << this->body->printString() << "\n}\n";
+    return ss.str();
 }
-
 
 string Hash::inspectObject() {
-  ostringstream ss;
-  vector<string> pairs{};
+    ostringstream ss;
+    vector<string> pairs{};
 
-  for (pair<size_t, shared_ptr<HashPair>> pair : this->pairs)
-    pairs.push_back(
-      pair.second->key->inspectObject() + ": "+ 
-      pair.second->value->inspectObject()
-    );
-  ss << "{";
-  for (string p : pairs)
-    ss << p + ", ";
-  ss << "}";
-  return ss.str();
+    for (pair<size_t, shared_ptr<HashPair>> pair : this->pairs)
+        pairs.push_back(
+            pair.second->key->inspectObject() + ": " + pair.second->value->inspectObject()
+        );
+    ss << "{";
+    for (string p : pairs)
+        ss << p + ", ";
+    ss << "}";
+    return ss.str();
 }
 
+string Integer::inspectType() { return ObjectType.INTEGER_OBJ; }
 
-string Integer::inspectType() {
-  return ObjectType.INTEGER_OBJ;
-}
+string Integer::inspectObject() { return to_string(this->value); }
 
-string Integer::inspectObject() {
-  return to_string(this->value);
-}
+string Null::inspectType() { return ObjectType.NULL_OBJ; }
 
+string Null::inspectObject() { return "null"; }
 
-string Null::inspectType() {
-  return ObjectType.NULL_OBJ;
-}
+string ReturnValue::inspectType() { return ObjectType.RETURN_OBJ; }
 
-string Null::inspectObject() {
-  return "null";
-}
+string ReturnValue::inspectObject() { return this->value->inspectObject(); }
 
+string String::inspectType() { return ObjectType.STRING_OBJ; }
 
-string ReturnValue::inspectType() {
-  return ObjectType.RETURN_OBJ;
-}
-
-string ReturnValue::inspectObject() {
-  return this->value->inspectObject();
-}
-
-
-string String::inspectType() {
-  return ObjectType.STRING_OBJ;
-}
-
-string String::inspectObject() {
-  return this->value;
-}
-
+string String::inspectObject() { return this->value; }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #include "ast.hpp"
-#include <sstream>
+
 #include <functional>
+#include <sstream>
 
 using namespace std;
 
@@ -19,57 +20,48 @@ class Null;
 class ReturnValue;
 class String;
 
-
 enum ObjectEnum {
-  ARRAY_OBJ,
-  BOOLEAN_FALSE,
-  BOOLEAN_TRUE,
-  BOOLEAN_OBJ,
-  BUILTIN_OBJ,
-  ERROR_OBJ,
-  FLOAT_OBJ,
-  FUNCTION_OBJ,
-  HASH_OBJ,
-  IDENT_OBJ,
-  INTEGER_OBJ,
-  LOOP_OBJ,
-  NULL_OBJ,
-  OBJECT_OBJ,
-  RETURN_OBJ,
-  STRING_OBJ,
+    ARRAY_OBJ,
+    BOOLEAN_FALSE,
+    BOOLEAN_TRUE,
+    BOOLEAN_OBJ,
+    BUILTIN_OBJ,
+    ERROR_OBJ,
+    FLOAT_OBJ,
+    FUNCTION_OBJ,
+    HASH_OBJ,
+    IDENT_OBJ,
+    INTEGER_OBJ,
+    LOOP_OBJ,
+    NULL_OBJ,
+    OBJECT_OBJ,
+    RETURN_OBJ,
+    STRING_OBJ,
 };
-
 
 enum FunctionEnum {
-  standardFunction,
-  builtinFunction,
+    standardFunction,
+    builtinFunction,
 };
 
-
-enum LoopEnum {
-  doLoop,
-  whileLoop,
-  forLoop
-};
-
+enum LoopEnum { doLoop, whileLoop, forLoop };
 
 const struct Objecttype {
-  string ARRAY_OBJ = {"ARRAY"};
-  string BOOLEAN_OBJ = {"BOOLEAN"};
-  string BUILTIN_OBJ = {"BUILTIN"};
-  string ERROR_OBJ = {"ERROR"};
-  string FLOAT_OBJ = {"FLOAT"};
-  string FUNCTION_OBJ = {"FUNCTION"};
-  string HASH_OBJ = {"HASH"};
-  string IDENT_OBJ = {"IDENT"};
-  string INTEGER_OBJ = {"INTEGER"};
-  string LOOP_OBJ = {"LOOP"};
-  string NULL_OBJ = {"NULL"};
-  string OBJECT_OBJ = {"OBJECT"};
-  string RETURN_OBJ = {"RETURN"};
-  string STRING_OBJ = {"STRING"};
+    string ARRAY_OBJ = {"ARRAY"};
+    string BOOLEAN_OBJ = {"BOOLEAN"};
+    string BUILTIN_OBJ = {"BUILTIN"};
+    string ERROR_OBJ = {"ERROR"};
+    string FLOAT_OBJ = {"FLOAT"};
+    string FUNCTION_OBJ = {"FUNCTION"};
+    string HASH_OBJ = {"HASH"};
+    string IDENT_OBJ = {"IDENT"};
+    string INTEGER_OBJ = {"INTEGER"};
+    string LOOP_OBJ = {"LOOP"};
+    string NULL_OBJ = {"NULL"};
+    string OBJECT_OBJ = {"OBJECT"};
+    string RETURN_OBJ = {"RETURN"};
+    string STRING_OBJ = {"STRING"};
 } ObjectType;
-
 
 class Object {
   public:
@@ -81,8 +73,7 @@ class Object {
     virtual string inspectObject();
 };
 
-
-class Array: public Object {
+class Array : public Object {
   public:
     Array(vector<shared_ptr<Object>>);
 
@@ -91,7 +82,6 @@ class Array: public Object {
     string inspectType();
     string inspectObject();
 };
-
 
 class Boolean : public Object {
   public:
@@ -102,7 +92,6 @@ class Boolean : public Object {
     string inspectType();
     string inspectObject();
 };
-
 
 class Environment : public Object {
   public:
@@ -117,7 +106,6 @@ class Environment : public Object {
     shared_ptr<Object> set(string, shared_ptr<Object>);
 };
 
-
 class Error : public Object {
   public:
     Error(string);
@@ -127,7 +115,6 @@ class Error : public Object {
     string inspectType();
     string inspectObject();
 };
-
 
 class Float : public Object {
   public:
@@ -139,25 +126,18 @@ class Float : public Object {
     string inspectObject();
 };
 
-
 class Function : public Object {
   public:
-    Function(
-      vector<shared_ptr<IdentifierLiteral>>, 
-      shared_ptr<BlockStatement>, 
-      shared_ptr<Environment>
-    );
+    Function(vector<shared_ptr<IdentifierLiteral>>, shared_ptr<BlockStatement>, shared_ptr<Environment>);
 
     vector<shared_ptr<IdentifierLiteral>> parameters;
     shared_ptr<BlockStatement> body;
     shared_ptr<Environment> env;
     int function_type;
 
-
     string inspectType();
     string inspectObject();
 };
-
 
 class Hash : public Object {
   public:
@@ -167,7 +147,6 @@ class Hash : public Object {
     string inspectObject();
 };
 
-
 class HashPair : public Object {
   public:
     HashPair(shared_ptr<Object>, shared_ptr<Object>);
@@ -175,7 +154,6 @@ class HashPair : public Object {
     shared_ptr<Object> key;
     shared_ptr<Object> value;
 };
-
 
 class Integer : public Object {
   public:
@@ -186,7 +164,6 @@ class Integer : public Object {
     string inspectType();
     string inspectObject();
 };
-
 
 class Loop : public Object {
   public:
@@ -203,7 +180,6 @@ class Loop : public Object {
     int increment;
 };
 
-
 class Null : public Object {
   public:
     Null();
@@ -211,7 +187,6 @@ class Null : public Object {
     string inspectType();
     string inspectObject();
 };
-
 
 class ReturnValue : public Object {
   public:
@@ -223,7 +198,6 @@ class ReturnValue : public Object {
     string inspectObject();
 };
 
-
 class String : public Object {
   public:
     String(string);
@@ -233,4 +207,3 @@ class String : public Object {
     string inspectType();
     string inspectObject();
 };
-

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,840 +1,784 @@
 #include "ast.hpp"
-#include <sstream>
+
 #include <memory>
+#include <sstream>
 using namespace std;
 
 Parser::Parser(string input) {
-  this->lexer = unique_ptr<Lexer> (new Lexer(input));
-  // reading two tokens so currentToken and peekToken both get set
-  this->nextToken();
-  this->nextToken();
+    this->lexer = unique_ptr<Lexer>(new Lexer(input));
+    // reading two tokens so currentToken and peekToken both get set
+    this->nextToken();
+    this->nextToken();
 }
-
 
 void Parser::checkFunctionReturn(shared_ptr<FunctionStatement> stmt) {
-  int found{0};
-  for (auto st : stmt->body->statements) {
-    if (st->type == returnStatement) {
-      shared_ptr<ReturnStatement> returnStmt = dynamic_pointer_cast<ReturnStatement>(st);
-      found ++;
-      if (stmt->datatype != returnStmt->datatype) {
-        ostringstream ss;
-        ss << "Function return value DataType mismatch.\n";
-        this->errors.push_back(ss.str());
-      }
+    int found{0};
+    for (auto st : stmt->body->statements) {
+        if (st->type == returnStatement) {
+            shared_ptr<ReturnStatement> returnStmt = dynamic_pointer_cast<ReturnStatement>(st);
+            found++;
+            if (stmt->datatype != returnStmt->datatype) {
+                ostringstream ss;
+                ss << "Function return value DataType mismatch.\n";
+                this->errors.push_back(ss.str());
+            }
+        }
     }
-  } 
-  if (!found) {
-    ostringstream ss;
-    ss << "No return statement for fn: " << stmt->token.literal << '\n';
-    this->errors.push_back(ss.str());
-  }
+    if (!found) {
+        ostringstream ss;
+        ss << "No return statement for fn: " << stmt->token.literal << '\n';
+        this->errors.push_back(ss.str());
+    }
 }
-
 
 void Parser::checkIdentifierDataType(shared_ptr<IdentifierStatement> stmt) {
-  switch (stmt->datatype) {
-    case INT:
-      if (DatatypeMap.at(stmt->value->type) != "int") {
-        ostringstream ss;
-        ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
-          << " is not equal to: " << "Integer Literal\n";
-        this->errors.push_back(ss.str());
-      }
-      break;
-    case FLOAT:
-      if (DatatypeMap.at(stmt->value->type) != "float") {
-        ostringstream ss;
-        ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
-          << " is not equal to: " << "Float \n";
-        this->errors.push_back(ss.str());
-      }
-      break;
-    case BOOLEAN:
-      if (DatatypeMap.at(stmt->value->type) != "boolean") {
-        ostringstream ss;
-        ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
-          << " is not equal to: " << "Boolean\n";
-        this->errors.push_back(ss.str());
-      }
-      break;
-    case _STRING:
-      if (DatatypeMap.at(stmt->value->type) != "string") {
-        ostringstream ss;
-        ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
-          << " is not equal to: " << "String \n";
-        this->errors.push_back(ss.str());
-      }
-      break;
-    case VOID:
-      ostringstream ss;
-      ss << "Cannot use void datatype with identifier initializations.\n";
-      this->errors.push_back(ss.str());
-      break;
-  }
+    switch (stmt->datatype) {
+        case INT:
+            if (DatatypeMap.at(stmt->value->type) != "int") {
+                ostringstream ss;
+                ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
+                   << " is not equal to: "
+                   << "Integer Literal\n";
+                this->errors.push_back(ss.str());
+            }
+            break;
+        case FLOAT:
+            if (DatatypeMap.at(stmt->value->type) != "float") {
+                ostringstream ss;
+                ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
+                   << " is not equal to: "
+                   << "Float \n";
+                this->errors.push_back(ss.str());
+            }
+            break;
+        case BOOLEAN:
+            if (DatatypeMap.at(stmt->value->type) != "boolean") {
+                ostringstream ss;
+                ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
+                   << " is not equal to: "
+                   << "Boolean\n";
+                this->errors.push_back(ss.str());
+            }
+            break;
+        case _STRING:
+            if (DatatypeMap.at(stmt->value->type) != "string") {
+                ostringstream ss;
+                ss << "Mismatched DataType: " << DatatypeMap.at(stmt->value->type)
+                   << " is not equal to: "
+                   << "String \n";
+                this->errors.push_back(ss.str());
+            }
+            break;
+        case VOID:
+            ostringstream ss;
+            ss << "Cannot use void datatype with identifier initializations.\n";
+            this->errors.push_back(ss.str());
+            break;
+    }
 }
-
 
 int Parser::currentPrecedence() {
-  int p;
-  try {
-    p = precedencesMap.at(this->currentToken.type);
-    return p;
-  }
-  catch (out_of_range&) {
-    return Precedences.LOWEST;
-  }
+    int p;
+    try {
+        p = precedencesMap.at(this->currentToken.type);
+        return p;
+    } catch (out_of_range&) {
+        return Precedences.LOWEST;
+    }
 }
-
 
 bool Parser::expectPeek(string tokentype) {
-  // checks the expected token, and if found, advances parser
-  if (this->peekToken.type == tokentype) {
-    this->nextToken();
-    return true;
-  }
-  this->peekErrors(tokentype);
-  return false;
+    // checks the expected token, and if found, advances parser
+    if (this->peekToken.type == tokentype) {
+        this->nextToken();
+        return true;
+    }
+    this->peekErrors(tokentype);
+    return false;
 }
-
 
 void Parser::nextToken() {
-  if (this->peekToken.type == TokenType.NEWLINE) { 
-    this->linenumber++; 
+    if (this->peekToken.type == TokenType.NEWLINE) {
+        this->linenumber++;
+        this->peekToken = this->lexer->nextToken();
+    }
+    this->currentToken = this->peekToken;
     this->peekToken = this->lexer->nextToken();
-  }
-  this->currentToken = this->peekToken;
-  this->peekToken = this->lexer->nextToken();
 }
-
 
 shared_ptr<ArrayLiteral> Parser::parseArrayLiteral() {
-  shared_ptr<ArrayLiteral> arr (new ArrayLiteral);
-  arr->setExpressionNode(this->currentToken);
-  arr->elements = this->parseExpressionList(TokenType.RBRACKET);
-  return arr;
+    shared_ptr<ArrayLiteral> arr(new ArrayLiteral);
+    arr->setExpressionNode(this->currentToken);
+    arr->elements = this->parseExpressionList(TokenType.RBRACKET);
+    return arr;
 }
-
 
 shared_ptr<AssignmentExpressionStatement> Parser::parseAssignmentExpression() {
-  shared_ptr<AssignmentExpressionStatement> expr (new AssignmentExpressionStatement);
-  expr->setStatementNode(this->currentToken);
+    shared_ptr<AssignmentExpressionStatement> expr(new AssignmentExpressionStatement);
+    expr->setStatementNode(this->currentToken);
 
-  expr->name = this->parseIdentifier();
-  this->nextToken();
-  expr->_operator = this->currentToken.literal;
-  int precedence = this->currentPrecedence();
-  this->nextToken();
-  expr->value = this->parseExpression(precedence);
-
-  // Read to end of line/file
-  while (1) {
-    if (this->currentToken.type == TokenType.SEMICOLON || this->currentToken.type == TokenType.RBRACE) {
-      break;
-    }
-    if (this->currentToken.type == TokenType._EOF) {
-      ostringstream ss;
-      ss << "No Semicolon present at end of line for " << StatementMap.at(expr->type) << 
-        " with value " << expr->value->token.literal;
-      this->errors.push_back(ss.str());
-      return nullptr;
-    }
+    expr->name = this->parseIdentifier();
     this->nextToken();
-  }
-  return expr;
-}
+    expr->_operator = this->currentToken.literal;
+    int precedence = this->currentPrecedence();
+    this->nextToken();
+    expr->value = this->parseExpression(precedence);
 
+    // Read to end of line/file
+    while (1) {
+        if (this->currentToken.type == TokenType.SEMICOLON ||
+            this->currentToken.type == TokenType.RBRACE) {
+            break;
+        }
+        if (this->currentToken.type == TokenType._EOF) {
+            ostringstream ss;
+            ss << "No Semicolon present at end of line for " << StatementMap.at(expr->type)
+               << " with value " << expr->value->token.literal;
+            this->errors.push_back(ss.str());
+            return nullptr;
+        }
+        this->nextToken();
+    }
+    return expr;
+}
 
 shared_ptr<BlockStatement> Parser::parseBlockStatement() {
-  shared_ptr<BlockStatement> block (new BlockStatement);
-  block->setStatementNode(this->currentToken);
-
-  this->nextToken();
-
-  while (this->currentToken.type != TokenType.RBRACE && this->currentToken.type != TokenType._EOF) {
-    shared_ptr<Statement> stmt = this->parseStatement();
-
-    if (stmt != nullptr)
-      block->statements.push_back(stmt);
+    shared_ptr<BlockStatement> block(new BlockStatement);
+    block->setStatementNode(this->currentToken);
 
     this->nextToken();
-  }
-  return block;
-}
 
+    while (this->currentToken.type != TokenType.RBRACE && this->currentToken.type != TokenType._EOF
+    ) {
+        shared_ptr<Statement> stmt = this->parseStatement();
+
+        if (stmt != nullptr) block->statements.push_back(stmt);
+
+        this->nextToken();
+    }
+    return block;
+}
 
 shared_ptr<BooleanLiteral> Parser::parseBooleanLiteral() {
-  shared_ptr<BooleanLiteral> expr (new BooleanLiteral);
-  expr->setExpressionNode(this->currentToken);
-  return expr;
+    shared_ptr<BooleanLiteral> expr(new BooleanLiteral);
+    expr->setExpressionNode(this->currentToken);
+    return expr;
 }
-
 
 shared_ptr<CallExpression> Parser::parseCallExpression(shared_ptr<Expression> func) {
-  shared_ptr<CallExpression> expr (new CallExpression);
-  expr->setExpressionNode(this->currentToken);
-  expr->_function = func;
-  expr->arguments = this->parseExpressionList(TokenType.RPAREN);
-  return expr;
+    shared_ptr<CallExpression> expr(new CallExpression);
+    expr->setExpressionNode(this->currentToken);
+    expr->_function = func;
+    expr->arguments = this->parseExpressionList(TokenType.RPAREN);
+    return expr;
 }
-
 
 shared_ptr<DoExpression> Parser::parseDoExpression() {
-  shared_ptr<DoExpression> expr (new DoExpression);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<DoExpression> expr(new DoExpression);
+    expr->setExpressionNode(this->currentToken);
 
-  if (!expectPeek(TokenType.LBRACE)) {
-    return nullptr;
-  }
+    if (!expectPeek(TokenType.LBRACE)) {
+        return nullptr;
+    }
 
-  expr->body = this->parseBlockStatement();
+    expr->body = this->parseBlockStatement();
 
-  if (!expectPeek(TokenType.WHILE)) {
-    return nullptr;
-  }
+    if (!expectPeek(TokenType.WHILE)) {
+        return nullptr;
+    }
 
-  if (!expectPeek(TokenType.LPAREN)) {
-    return nullptr;
-  }
-  this->nextToken();
+    if (!expectPeek(TokenType.LPAREN)) {
+        return nullptr;
+    }
+    this->nextToken();
 
-  expr->condition = this->parseExpression(Precedences.LOWEST);
+    expr->condition = this->parseExpression(Precedences.LOWEST);
 
-  if (!expectPeek(TokenType.RPAREN)) {
-    return nullptr;
-  }
+    if (!expectPeek(TokenType.RPAREN)) {
+        return nullptr;
+    }
 
-  return expr;
+    return expr;
 }
-
 
 shared_ptr<Expression> Parser::parseExpression(int precedence) {
-  auto prefix = prefixFunctions.find(this->currentToken.type);
-  if (prefix == prefixFunctions.end()) {
-    ostringstream ss;
-    ss << "No prefix parse function found for " << this->currentToken.literal << '\n';
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-
-  shared_ptr<Expression> leftExp = this->parseLeftPrefix(prefix->second);
-  if (leftExp == nullptr) {
-    ostringstream ss;
-    ss << "Left expression is invalid.\n";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-  leftExp->setDataType(leftExp->token.literal);
-
-  while (this->peekToken.type != TokenType.SEMICOLON && precedence < this->peekPrecedence()) 
-  {
-    auto infix = infixFunctions.find(this->peekToken.type);
-    if (infix == infixFunctions.end()) {
-      auto postfix = postfixFunctions.find(this->peekToken.type);
-      if (postfix != postfixFunctions.end()) {
-        this->nextToken();
-        leftExp = this->parsePostfixExpression(leftExp);
-        this->nextToken();
-        return leftExp;
-      }
+    auto prefix = prefixFunctions.find(this->currentToken.type);
+    if (prefix == prefixFunctions.end()) {
+        ostringstream ss;
+        ss << "No prefix parse function found for " << this->currentToken.literal << '\n';
+        this->errors.push_back(ss.str());
+        return nullptr;
     }
-    this->nextToken();
 
-    switch (infix->second) {
-      case INFIX_STD:
-        leftExp = this->parseInfixExpression(leftExp);
-        break;
-      case INFIX_CALL:
-        leftExp = this->parseCallExpression(leftExp);
-        break;
-      case INFIX_INDEX:
-        leftExp = this->parseIndexExpression(leftExp);
-        break;
+    shared_ptr<Expression> leftExp = this->parseLeftPrefix(prefix->second);
+    if (leftExp == nullptr) {
+        ostringstream ss;
+        ss << "Left expression is invalid.\n";
+        this->errors.push_back(ss.str());
+        return nullptr;
     }
-  }
-  return leftExp;
+    leftExp->setDataType(leftExp->token.literal);
+
+    while (this->peekToken.type != TokenType.SEMICOLON && precedence < this->peekPrecedence()) {
+        auto infix = infixFunctions.find(this->peekToken.type);
+        if (infix == infixFunctions.end()) {
+            auto postfix = postfixFunctions.find(this->peekToken.type);
+            if (postfix != postfixFunctions.end()) {
+                this->nextToken();
+                leftExp = this->parsePostfixExpression(leftExp);
+                this->nextToken();
+                return leftExp;
+            }
+        }
+        this->nextToken();
+
+        switch (infix->second) {
+            case INFIX_STD:
+                leftExp = this->parseInfixExpression(leftExp);
+                break;
+            case INFIX_CALL:
+                leftExp = this->parseCallExpression(leftExp);
+                break;
+            case INFIX_INDEX:
+                leftExp = this->parseIndexExpression(leftExp);
+                break;
+        }
+    }
+    return leftExp;
 }
-
 
 vector<shared_ptr<Expression>> Parser::parseExpressionList(string end) {
-  vector<shared_ptr<Expression>> list{};
+    vector<shared_ptr<Expression>> list{};
 
-  if (this->peekToken.type == end) {
-    this->nextToken();
-    return list;
-  }
+    if (this->peekToken.type == end) {
+        this->nextToken();
+        return list;
+    }
 
-  this->nextToken();
-  list.push_back(this->parseExpression(Precedences.LOWEST));
-
-  while (this->peekToken.type == TokenType.COMMA) {
-    this->nextToken();
     this->nextToken();
     list.push_back(this->parseExpression(Precedences.LOWEST));
-  }
 
-  if (!expectPeek(end)) {
-    ostringstream ss;
-    ss << "Parenthesis/Bracket never closed\n";
-    this->errors.push_back(ss.str());
-  }
+    while (this->peekToken.type == TokenType.COMMA) {
+        this->nextToken();
+        this->nextToken();
+        list.push_back(this->parseExpression(Precedences.LOWEST));
+    }
 
-  return list;
+    if (!expectPeek(end)) {
+        ostringstream ss;
+        ss << "Parenthesis/Bracket never closed\n";
+        this->errors.push_back(ss.str());
+    }
+
+    return list;
 }
-
 
 shared_ptr<ExpressionStatement> Parser::parseExpressionStatement() {
-  shared_ptr<ExpressionStatement> stmt (new ExpressionStatement);
-  stmt->setStatementNode(this->currentToken);
-  stmt->expression = this->parseExpression(Precedences.LOWEST);
+    shared_ptr<ExpressionStatement> stmt(new ExpressionStatement);
+    stmt->setStatementNode(this->currentToken);
+    stmt->expression = this->parseExpression(Precedences.LOWEST);
 
-  if (this->peekToken.type == TokenType.SEMICOLON || this->peekToken.type == TokenType._EOF) {
-    this->nextToken();
-  }
-  return stmt;
+    if (this->peekToken.type == TokenType.SEMICOLON || this->peekToken.type == TokenType._EOF) {
+        this->nextToken();
+    }
+    return stmt;
 }
 
-
 shared_ptr<FloatLiteral> Parser::parseFloatLiteral() {
-  shared_ptr<FloatLiteral> expr (new FloatLiteral);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<FloatLiteral> expr(new FloatLiteral);
+    expr->setExpressionNode(this->currentToken);
 
-  float value;
-  try {
-    value = stof(this->currentToken.literal);
-  }
-  catch (...) {
-    ostringstream ss;
-    ss << "Could not parse " << this->currentToken.literal << " as float";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-  expr->value = value;
+    float value;
+    try {
+        value = stof(this->currentToken.literal);
+    } catch (...) {
+        ostringstream ss;
+        ss << "Could not parse " << this->currentToken.literal << " as float";
+        this->errors.push_back(ss.str());
+        return nullptr;
+    }
+    expr->value = value;
 
-  return expr;
+    return expr;
 }
 
 shared_ptr<ForExpression> Parser::parseForExpression() {
-  shared_ptr<ForExpression> loop (new ForExpression);
-  loop->setExpressionNode(this->currentToken);
+    shared_ptr<ForExpression> loop(new ForExpression);
+    loop->setExpressionNode(this->currentToken);
 
-  if (!expectPeek(TokenType.LPAREN))
-    return nullptr;
+    if (!expectPeek(TokenType.LPAREN)) return nullptr;
 
-  this->nextToken();
-
-  vector<shared_ptr<LetStatement>> statements{};
-  while (this->currentToken.type != TokenType.IN) {
-    shared_ptr<LetStatement> stmt (new LetStatement);
-    stmt->setStatementNode(this->currentToken);
-    stmt->name = this->parseIdentifier();
-    statements.push_back(stmt);
     this->nextToken();
-  }
 
-  if (!(expectPeek(TokenType.INT)))
-    return nullptr;
+    vector<shared_ptr<LetStatement>> statements{};
+    while (this->currentToken.type != TokenType.IN) {
+        shared_ptr<LetStatement> stmt(new LetStatement);
+        stmt->setStatementNode(this->currentToken);
+        stmt->name = this->parseIdentifier();
+        statements.push_back(stmt);
+        this->nextToken();
+    }
 
-  shared_ptr<Expression> start = this->parseIntegerLiteral();
-  loop->start = start;
-  for (auto stmt : statements) {
-    stmt->value = start;
-    loop->statements.push_back(stmt);
-  }
-  if (!(expectPeek(TokenType.COLON)))
-    return nullptr;
-  if (!(expectPeek(TokenType.INT)))
-    return nullptr;
+    if (!(expectPeek(TokenType.INT))) return nullptr;
 
-  shared_ptr<Expression> end = this->parseIntegerLiteral();
-  shared_ptr<Expression> increment = nullptr;
-  loop->end = end;
-  this->nextToken();
+    shared_ptr<Expression> start = this->parseIntegerLiteral();
+    loop->start = start;
+    for (auto stmt : statements) {
+        stmt->value = start;
+        loop->statements.push_back(stmt);
+    }
+    if (!(expectPeek(TokenType.COLON))) return nullptr;
+    if (!(expectPeek(TokenType.INT))) return nullptr;
 
-  if (this->currentToken.type == TokenType.RPAREN) {
-    shared_ptr<IntegerLiteral> inc (new IntegerLiteral);
-    inc->token.type = TokenType.INT;
-    inc->token.literal = "1";
-    inc->value = 1;
-    increment = inc;
-  }
-  else if (this->currentToken.type == TokenType.COLON) {
+    shared_ptr<Expression> end = this->parseIntegerLiteral();
+    shared_ptr<Expression> increment = nullptr;
+    loop->end = end;
     this->nextToken();
-    if (this->currentToken.type != TokenType.INT)
-      return nullptr;
-    increment = this->parseIntegerLiteral();
-    if (this->peekToken.type != TokenType.RPAREN)
-      return nullptr;
-  }
-  else {
-    ostringstream ss;
-    ss << "Could not parse for-loop";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-  loop->increment = increment;
 
-  if (!(expectPeek(TokenType.LBRACE)))
-    return nullptr;
+    if (this->currentToken.type == TokenType.RPAREN) {
+        shared_ptr<IntegerLiteral> inc(new IntegerLiteral);
+        inc->token.type = TokenType.INT;
+        inc->token.literal = "1";
+        inc->value = 1;
+        increment = inc;
+    } else if (this->currentToken.type == TokenType.COLON) {
+        this->nextToken();
+        if (this->currentToken.type != TokenType.INT) return nullptr;
+        increment = this->parseIntegerLiteral();
+        if (this->peekToken.type != TokenType.RPAREN) return nullptr;
+    } else {
+        ostringstream ss;
+        ss << "Could not parse for-loop";
+        this->errors.push_back(ss.str());
+        return nullptr;
+    }
+    loop->increment = increment;
 
-  loop->body = this->parseBlockStatement();
+    if (!(expectPeek(TokenType.LBRACE))) return nullptr;
 
-  return loop;
+    loop->body = this->parseBlockStatement();
+
+    return loop;
 }
-
 
 shared_ptr<FunctionLiteral> Parser::parseFunctionLiteral() {
-  shared_ptr<FunctionLiteral> expr (new FunctionLiteral);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<FunctionLiteral> expr(new FunctionLiteral);
+    expr->setExpressionNode(this->currentToken);
 
-  if (!expectPeek(TokenType.IDENT))
-    return nullptr;
-  expr->name = parseIdentifier();
+    if (!expectPeek(TokenType.IDENT)) return nullptr;
+    expr->name = parseIdentifier();
 
-  if (!expectPeek(TokenType.LPAREN))
-    return nullptr;
-  expr->parameters = this->parseFunctionParameters();
+    if (!expectPeek(TokenType.LPAREN)) return nullptr;
+    expr->parameters = this->parseFunctionParameters();
 
-  if (!expectPeek(TokenType.LBRACE))
-    return nullptr;
-  expr->body = this->parseBlockStatement();
+    if (!expectPeek(TokenType.LBRACE)) return nullptr;
+    expr->body = this->parseBlockStatement();
 
-  return expr;
+    return expr;
 }
-
 
 shared_ptr<FunctionStatement> Parser::parseFunctionStatement() {
-  shared_ptr<FunctionStatement> stmt (new FunctionStatement);
-  stmt->setStatementNode(this->currentToken);
-  stmt->setDataType(this->currentToken.literal);
+    shared_ptr<FunctionStatement> stmt(new FunctionStatement);
+    stmt->setStatementNode(this->currentToken);
+    stmt->setDataType(this->currentToken.literal);
 
-  this->nextToken();
+    this->nextToken();
 
-  if (!expectPeek(TokenType.IDENT))
-    return nullptr;
-  stmt->name = parseIdentifier();
-  this->nextToken();
+    if (!expectPeek(TokenType.IDENT)) return nullptr;
+    stmt->name = parseIdentifier();
+    this->nextToken();
 
-  if (!expectPeek(TokenType.LPAREN))
-    return nullptr;
-  stmt->parameters = this->parseFunctionParameters();
+    if (!expectPeek(TokenType.LPAREN)) return nullptr;
+    stmt->parameters = this->parseFunctionParameters();
 
-  if (!expectPeek(TokenType.LBRACE))
-    return nullptr;
-  stmt->body = this->parseBlockStatement();
-  // make sure return datatype is the same as funtion datatype
-  this->checkFunctionReturn(stmt);
+    if (!expectPeek(TokenType.LBRACE)) return nullptr;
+    stmt->body = this->parseBlockStatement();
+    // make sure return datatype is the same as funtion datatype
+    this->checkFunctionReturn(stmt);
 
-  return stmt;
+    return stmt;
 }
-
 
 vector<shared_ptr<IdentifierLiteral>> Parser::parseFunctionParameters() {
-  vector<shared_ptr<IdentifierLiteral>> identifiers{};
-  if (this->peekToken.type == TokenType.RPAREN) {
-    this->nextToken();
-    return identifiers;
-  }
+    vector<shared_ptr<IdentifierLiteral>> identifiers{};
+    if (this->peekToken.type == TokenType.RPAREN) {
+        this->nextToken();
+        return identifiers;
+    }
 
-  this->nextToken();
-  shared_ptr<IdentifierLiteral> ident (new IdentifierLiteral);
-  ident->setExpressionNode(this->currentToken);
-  identifiers.push_back(ident);
-
-  while (this->peekToken.type == TokenType.COMMA) {
     this->nextToken();
-    this->nextToken();
-    shared_ptr<IdentifierLiteral> ident (new IdentifierLiteral);
+    shared_ptr<IdentifierLiteral> ident(new IdentifierLiteral);
     ident->setExpressionNode(this->currentToken);
     identifiers.push_back(ident);
-  }
 
-  if (!expectPeek(TokenType.RPAREN)) {
-    ostringstream ss;
-    ss << "Parenthesis never closed for function\n";
-    this->errors.push_back(ss.str());
-  }
+    while (this->peekToken.type == TokenType.COMMA) {
+        this->nextToken();
+        this->nextToken();
+        shared_ptr<IdentifierLiteral> ident(new IdentifierLiteral);
+        ident->setExpressionNode(this->currentToken);
+        identifiers.push_back(ident);
+    }
 
-  return identifiers;
+    if (!expectPeek(TokenType.RPAREN)) {
+        ostringstream ss;
+        ss << "Parenthesis never closed for function\n";
+        this->errors.push_back(ss.str());
+    }
+
+    return identifiers;
 }
-
 
 shared_ptr<HashLiteral> Parser::parseHashLiteral() {
-  shared_ptr<HashLiteral> hash (new HashLiteral);
-  hash->setExpressionNode(this->currentToken);
+    shared_ptr<HashLiteral> hash(new HashLiteral);
+    hash->setExpressionNode(this->currentToken);
 
-  while (this->peekToken.type != TokenType.RBRACE) {
-    if (this->currentToken.type == TokenType._EOF) {
-      ostringstream ss;
-      ss << "Brace never closed\n";
-      this->errors.push_back(ss.str());
+    while (this->peekToken.type != TokenType.RBRACE) {
+        if (this->currentToken.type == TokenType._EOF) {
+            ostringstream ss;
+            ss << "Brace never closed\n";
+            this->errors.push_back(ss.str());
+        }
+        this->nextToken();
+        shared_ptr<Expression> key = this->parseExpression(Precedences.LOWEST);
+
+        if (!expectPeek(TokenType.COLON)) return nullptr;
+
+        this->nextToken();
+        shared_ptr<Expression> value = this->parseExpression(Precedences.LOWEST);
+        hash->pairs[key] = value;
+
+        if (this->peekToken.type != TokenType.RBRACE && !expectPeek(TokenType.COMMA))
+            return nullptr;
     }
-    this->nextToken();
-    shared_ptr<Expression> key = this->parseExpression(Precedences.LOWEST);
 
-    if (!expectPeek(TokenType.COLON))
-      return nullptr;
-
-    this->nextToken();
-    shared_ptr<Expression> value = this->parseExpression(Precedences.LOWEST);
-    hash->pairs[key] = value;
-
-    if (this->peekToken.type != TokenType.RBRACE && !expectPeek(TokenType.COMMA))
-      return nullptr;
-  }
-
-  if (!expectPeek(TokenType.RBRACE))
-    return nullptr;
-  return hash;
+    if (!expectPeek(TokenType.RBRACE)) return nullptr;
+    return hash;
 }
-
 
 shared_ptr<IdentifierLiteral> Parser::parseIdentifier() {
-  shared_ptr<IdentifierLiteral> idp (new IdentifierLiteral);
-  idp->setExpressionNode(this->currentToken);
-  return idp;
+    shared_ptr<IdentifierLiteral> idp(new IdentifierLiteral);
+    idp->setExpressionNode(this->currentToken);
+    return idp;
 }
-
 
 shared_ptr<Expression> Parser::parseGroupedExpression() {
-  this->nextToken();
-  shared_ptr<Expression> expr = this->parseExpression(Precedences.LOWEST);
-  if (!expectPeek(TokenType.RPAREN)) {
-    return nullptr;
-  }
-  return expr;
+    this->nextToken();
+    shared_ptr<Expression> expr = this->parseExpression(Precedences.LOWEST);
+    if (!expectPeek(TokenType.RPAREN)) {
+        return nullptr;
+    }
+    return expr;
 }
-
 
 shared_ptr<IdentifierStatement> Parser::parseIdentifierStatement() {
-  // Initializing statement values
-  shared_ptr<IdentifierStatement> stmt (new IdentifierStatement);
-  stmt->setStatementNode(this->currentToken);
-  stmt->setDataType(this->currentToken.literal);
+    // Initializing statement values
+    shared_ptr<IdentifierStatement> stmt(new IdentifierStatement);
+    stmt->setStatementNode(this->currentToken);
+    stmt->setDataType(this->currentToken.literal);
 
-  this->nextToken();
-
-  // Getting the identifier
-  stmt->name = this->parseIdentifier();
-
-  if (!expectPeek(TokenType.ASSIGN)) {
-    ostringstream ss;
-    ss << "line:" << this->linenumber << ": Could not parse " << 
-      this->currentToken.literal << "; no assignment operator";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-
-  // Setting expression value
-  this->nextToken();
-  stmt->value = this->parseExpression(Precedences.LOWEST);
-
-  this->checkIdentifierDataType(stmt);
-
-  // Read to end of line/file
-  while (this->currentToken.type != TokenType.SEMICOLON) {
-    if (this->currentToken.type == TokenType._EOF) {
-      ostringstream ss;
-      ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type) << 
-        " with value " << stmt->value->token.literal;
-      this->errors.push_back(ss.str());
-      return nullptr;
-    }
     this->nextToken();
-  }
 
-  return stmt;
+    // Getting the identifier
+    stmt->name = this->parseIdentifier();
+
+    if (!expectPeek(TokenType.ASSIGN)) {
+        ostringstream ss;
+        ss << "line:" << this->linenumber << ": Could not parse " << this->currentToken.literal
+           << "; no assignment operator";
+        this->errors.push_back(ss.str());
+        return nullptr;
+    }
+
+    // Setting expression value
+    this->nextToken();
+    stmt->value = this->parseExpression(Precedences.LOWEST);
+
+    this->checkIdentifierDataType(stmt);
+
+    // Read to end of line/file
+    while (this->currentToken.type != TokenType.SEMICOLON) {
+        if (this->currentToken.type == TokenType._EOF) {
+            ostringstream ss;
+            ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type)
+               << " with value " << stmt->value->token.literal;
+            this->errors.push_back(ss.str());
+            return nullptr;
+        }
+        this->nextToken();
+    }
+
+    return stmt;
 }
-
 
 shared_ptr<IfExpression> Parser::parseIfExpression() {
-  shared_ptr<IfExpression> expr (new IfExpression);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<IfExpression> expr(new IfExpression);
+    expr->setExpressionNode(this->currentToken);
 
-  if (!expectPeek(TokenType.LPAREN)) {
-    return nullptr;
-  }
-
-  this->nextToken();
-  expr->condition = this->parseExpression(Precedences.LOWEST);
-
-  if (!expectPeek(TokenType.RPAREN)) {
-    return nullptr;
-  }
-
-  if (!expectPeek(TokenType.LBRACE)) {
-    return nullptr;
-  }
-  expr->consequence = this->parseBlockStatement();
-
-  // loop for any else-if conditions
-  while (this->peekToken.type == TokenType.ELSE) {
-    this->nextToken();
-    if (this->peekToken.type == TokenType.IF) 
-    {
-      this->nextToken();
-      if (!expectPeek(TokenType.LPAREN)) { return nullptr; }
-      this->nextToken();
-      expr->conditions.push_back( this->parseExpression(Precedences.LOWEST) );
-      if (!expectPeek(TokenType.RPAREN)) { return nullptr; }
-      if (!expectPeek(TokenType.LBRACE)) { return nullptr; }
-      expr->alternatives.push_back ( this->parseBlockStatement() );
-    }
-    else 
-    {
-      if (!expectPeek(TokenType.LBRACE)) {
+    if (!expectPeek(TokenType.LPAREN)) {
         return nullptr;
-      }
-      expr->alternative = this->parseBlockStatement();
     }
-  }
-  return expr;
-}
 
+    this->nextToken();
+    expr->condition = this->parseExpression(Precedences.LOWEST);
+
+    if (!expectPeek(TokenType.RPAREN)) {
+        return nullptr;
+    }
+
+    if (!expectPeek(TokenType.LBRACE)) {
+        return nullptr;
+    }
+    expr->consequence = this->parseBlockStatement();
+
+    // loop for any else-if conditions
+    while (this->peekToken.type == TokenType.ELSE) {
+        this->nextToken();
+        if (this->peekToken.type == TokenType.IF) {
+            this->nextToken();
+            if (!expectPeek(TokenType.LPAREN)) {
+                return nullptr;
+            }
+            this->nextToken();
+            expr->conditions.push_back(this->parseExpression(Precedences.LOWEST));
+            if (!expectPeek(TokenType.RPAREN)) {
+                return nullptr;
+            }
+            if (!expectPeek(TokenType.LBRACE)) {
+                return nullptr;
+            }
+            expr->alternatives.push_back(this->parseBlockStatement());
+        } else {
+            if (!expectPeek(TokenType.LBRACE)) {
+                return nullptr;
+            }
+            expr->alternative = this->parseBlockStatement();
+        }
+    }
+    return expr;
+}
 
 shared_ptr<Expression> Parser::parseIndexExpression(shared_ptr<Expression> _left) {
-  shared_ptr<IndexExpression> expr (new IndexExpression);
-  expr->setExpressionNode(this->currentToken);
-  expr->_left = _left;
+    shared_ptr<IndexExpression> expr(new IndexExpression);
+    expr->setExpressionNode(this->currentToken);
+    expr->_left = _left;
 
-  this->nextToken();
-  expr->index = this->parseExpression(Precedences.LOWEST);
+    this->nextToken();
+    expr->index = this->parseExpression(Precedences.LOWEST);
 
-  if (!expectPeek(TokenType.RBRACKET)) {
-    ostringstream ss;
-    ss << "Index Bracket never closed\n";
-    this->errors.push_back(ss.str());
-  }
-  
-  return expr;
+    if (!expectPeek(TokenType.RBRACKET)) {
+        ostringstream ss;
+        ss << "Index Bracket never closed\n";
+        this->errors.push_back(ss.str());
+    }
+
+    return expr;
 }
-
 
 shared_ptr<InfixExpression> Parser::parseInfixExpression(shared_ptr<Expression> leftExpr) {
-  shared_ptr<InfixExpression> expr (new InfixExpression);
-  expr->setExpressionNode(this->currentToken);
-  expr->_left = leftExpr;
+    shared_ptr<InfixExpression> expr(new InfixExpression);
+    expr->setExpressionNode(this->currentToken);
+    expr->_left = leftExpr;
 
-  int precedence = this->currentPrecedence();
-  this->nextToken();
+    int precedence = this->currentPrecedence();
+    this->nextToken();
 
-  expr->_right = this->parseExpression(precedence);
+    expr->_right = this->parseExpression(precedence);
 
-  return expr;
+    return expr;
 }
-
 
 shared_ptr<IntegerLiteral> Parser::parseIntegerLiteral() {
-  shared_ptr<IntegerLiteral> expr (new IntegerLiteral);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<IntegerLiteral> expr(new IntegerLiteral);
+    expr->setExpressionNode(this->currentToken);
 
-  int value;
-  try {
-    value = stoi(this->currentToken.literal);
-  }
-  catch (...) {
-    ostringstream ss;
-    ss << "Could not parse " << this->currentToken.literal << " as integer";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-  expr->value = value;
+    int value;
+    try {
+        value = stoi(this->currentToken.literal);
+    } catch (...) {
+        ostringstream ss;
+        ss << "Could not parse " << this->currentToken.literal << " as integer";
+        this->errors.push_back(ss.str());
+        return nullptr;
+    }
+    expr->value = value;
 
-  return expr;
+    return expr;
 }
-
 
 shared_ptr<Expression> Parser::parseLeftPrefix(int prefix) {
-  switch (prefix) {
-    case PREFIX_IDENT:
-      return this->parseIdentifier();
-    case PREFIX_INT:
-      return this->parseIntegerLiteral();
-    case PREFIX_FLOAT:
-      return this->parseFloatLiteral();
-    case PREFIX_STRING:
-      return this->parseStringLiteral();
-    case PREFIX_BOOL:
-      return this->parseBooleanLiteral();
-    case PREFIX_IF:
-      return this->parseIfExpression();
-    case PREFIX_GROUPED_EXPR:
-      return this->parseGroupedExpression();
-    case PREFIX_FUNCTION:
-      return this->parseFunctionLiteral();
-    case PREFIX_WHILE:
-      return this->parseWhileExpression();
-    case PREFIX_DO:
-      return this->parseDoExpression();
-    case PREFIX_FOR:
-      return this->parseForExpression();
-    case PREFIX_ARRAY:
-      return this->parseArrayLiteral();
-    case PREFIX_HASH:
-      return this->parseHashLiteral();
-    default:
-      return this->parsePrefixExpression();
-  }
+    switch (prefix) {
+        case PREFIX_IDENT:
+            return this->parseIdentifier();
+        case PREFIX_INT:
+            return this->parseIntegerLiteral();
+        case PREFIX_FLOAT:
+            return this->parseFloatLiteral();
+        case PREFIX_STRING:
+            return this->parseStringLiteral();
+        case PREFIX_BOOL:
+            return this->parseBooleanLiteral();
+        case PREFIX_IF:
+            return this->parseIfExpression();
+        case PREFIX_GROUPED_EXPR:
+            return this->parseGroupedExpression();
+        case PREFIX_FUNCTION:
+            return this->parseFunctionLiteral();
+        case PREFIX_WHILE:
+            return this->parseWhileExpression();
+        case PREFIX_DO:
+            return this->parseDoExpression();
+        case PREFIX_FOR:
+            return this->parseForExpression();
+        case PREFIX_ARRAY:
+            return this->parseArrayLiteral();
+        case PREFIX_HASH:
+            return this->parseHashLiteral();
+        default:
+            return this->parsePrefixExpression();
+    }
 }
-
 
 shared_ptr<LetStatement> Parser::parseLetStatement() {
-  // Initializing statement values
-  shared_ptr<LetStatement> stmt (new LetStatement);
-  stmt->setStatementNode(this->currentToken);
+    // Initializing statement values
+    shared_ptr<LetStatement> stmt(new LetStatement);
+    stmt->setStatementNode(this->currentToken);
 
-  // If no identifier found
-  if (!expectPeek(TokenType.IDENT)) {
-    ostringstream ss;
-    ss << "Could not parse " << this->currentToken.literal << "; no identifier given";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-
-  // Getting the identifier
-  stmt->name = this->parseIdentifier();
-
-  if (!expectPeek(TokenType.ASSIGN)) {
-    ostringstream ss;
-    ss << "Could not parse " << this->currentToken.literal << "; no assignment operator";
-    this->errors.push_back(ss.str());
-    return nullptr;
-  }
-
-  // Setting expression value
-  this->nextToken();
-  stmt->value = this->parseExpression(Precedences.LOWEST);
-
-  // Read to end of line/file
-  while (this->currentToken.type != TokenType.SEMICOLON) {
-    if (this->currentToken.type == TokenType._EOF) {
-      ostringstream ss;
-      ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type) << 
-        " with value " << stmt->value->token.literal;
-      this->errors.push_back(ss.str());
-      return nullptr;
+    // If no identifier found
+    if (!expectPeek(TokenType.IDENT)) {
+        ostringstream ss;
+        ss << "Could not parse " << this->currentToken.literal << "; no identifier given";
+        this->errors.push_back(ss.str());
+        return nullptr;
     }
+
+    // Getting the identifier
+    stmt->name = this->parseIdentifier();
+
+    if (!expectPeek(TokenType.ASSIGN)) {
+        ostringstream ss;
+        ss << "Could not parse " << this->currentToken.literal << "; no assignment operator";
+        this->errors.push_back(ss.str());
+        return nullptr;
+    }
+
+    // Setting expression value
     this->nextToken();
-  }
+    stmt->value = this->parseExpression(Precedences.LOWEST);
 
-  return stmt;
+    // Read to end of line/file
+    while (this->currentToken.type != TokenType.SEMICOLON) {
+        if (this->currentToken.type == TokenType._EOF) {
+            ostringstream ss;
+            ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type)
+               << " with value " << stmt->value->token.literal;
+            this->errors.push_back(ss.str());
+            return nullptr;
+        }
+        this->nextToken();
+    }
+
+    return stmt;
 }
-
 
 shared_ptr<PostfixExpression> Parser::parsePostfixExpression(shared_ptr<Expression> leftExpr) {
-  shared_ptr<PostfixExpression> expr (new PostfixExpression);
-  expr->setExpressionNode(this->currentToken);
-  expr->_left = leftExpr;
-  return expr;
+    shared_ptr<PostfixExpression> expr(new PostfixExpression);
+    expr->setExpressionNode(this->currentToken);
+    expr->_left = leftExpr;
+    return expr;
 }
-
 
 shared_ptr<PrefixExpression> Parser::parsePrefixExpression() {
-  shared_ptr<PrefixExpression> expr (new PrefixExpression);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<PrefixExpression> expr(new PrefixExpression);
+    expr->setExpressionNode(this->currentToken);
 
-  this->nextToken();
+    this->nextToken();
 
-  expr->_right = this->parseExpression(Precedences.PREFIX);
-  return expr;
+    expr->_right = this->parseExpression(Precedences.PREFIX);
+    return expr;
 }
-
 
 shared_ptr<ReturnStatement> Parser::parseReturnStatement() {
-  shared_ptr<ReturnStatement> stmt (new ReturnStatement);
-  stmt->setStatementNode(this->currentToken);
-  this->nextToken();
-
-  stmt->returnValue = this->parseExpression(Precedences.LOWEST);
-  if (stmt->returnValue == nullptr) {
-    stmt->datatype = VOID;
-  }
-  else {
-    stmt->datatype = stmt->returnValue->datatype;
-  }
-
-  while (this->currentToken.type != TokenType.SEMICOLON) {
-    if (this->currentToken.type == TokenType._EOF) {
-      ostringstream ss;
-      ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type) << 
-        " with value " << stmt->returnValue->token.literal;
-      this->errors.push_back(ss.str());
-      return nullptr;
-    }
+    shared_ptr<ReturnStatement> stmt(new ReturnStatement);
+    stmt->setStatementNode(this->currentToken);
     this->nextToken();
-  }
-  return stmt;
-}
 
+    stmt->returnValue = this->parseExpression(Precedences.LOWEST);
+    if (stmt->returnValue == nullptr) {
+        stmt->datatype = VOID;
+    } else {
+        stmt->datatype = stmt->returnValue->datatype;
+    }
+
+    while (this->currentToken.type != TokenType.SEMICOLON) {
+        if (this->currentToken.type == TokenType._EOF) {
+            ostringstream ss;
+            ss << "No Semicolon present at end of line for " << StatementMap.at(stmt->type)
+               << " with value " << stmt->returnValue->token.literal;
+            this->errors.push_back(ss.str());
+            return nullptr;
+        }
+        this->nextToken();
+    }
+    return stmt;
+}
 
 shared_ptr<Statement> Parser::parseStatement() {
-  string curr = this->currentToken.type;
-  string peek = this->peekToken.type;
-  // if starts with optional datatype declaration
-  if (curr == TokenType.DATATYPE) {
-    if (peek == TokenType.IDENT)
-      return this->parseIdentifierStatement();
-    if (peek == TokenType.FUNCTION)
-      return this->parseFunctionStatement();
-  }
-  else if (curr == TokenType.LET)
-    return this->parseLetStatement();
-  else if (curr == TokenType.RETURN)
-    return this->parseReturnStatement();
-  else if (curr == TokenType.IDENT && peek == TokenType.ASSIGN_EQ)
-    return this->parseAssignmentExpression();
-  else 
-    return this->parseExpressionStatement();
-  return nullptr;
+    string curr = this->currentToken.type;
+    string peek = this->peekToken.type;
+    // if starts with optional datatype declaration
+    if (curr == TokenType.DATATYPE) {
+        if (peek == TokenType.IDENT) return this->parseIdentifierStatement();
+        if (peek == TokenType.FUNCTION) return this->parseFunctionStatement();
+    } else if (curr == TokenType.LET) return this->parseLetStatement();
+    else if (curr == TokenType.RETURN) return this->parseReturnStatement();
+    else if (curr == TokenType.IDENT && peek == TokenType.ASSIGN_EQ)
+        return this->parseAssignmentExpression();
+    else return this->parseExpressionStatement();
+    return nullptr;
 }
-
 
 shared_ptr<StringLiteral> Parser::parseStringLiteral() {
-  shared_ptr<StringLiteral> expr (new StringLiteral);
-  expr->setExpressionNode(this->currentToken);
-  return expr;
+    shared_ptr<StringLiteral> expr(new StringLiteral);
+    expr->setExpressionNode(this->currentToken);
+    return expr;
 }
-
 
 shared_ptr<WhileExpression> Parser::parseWhileExpression() {
-  shared_ptr<WhileExpression> expr (new WhileExpression);
-  expr->setExpressionNode(this->currentToken);
+    shared_ptr<WhileExpression> expr(new WhileExpression);
+    expr->setExpressionNode(this->currentToken);
 
-  if (!expectPeek(TokenType.LPAREN)) {
-    return nullptr;
-  }
+    if (!expectPeek(TokenType.LPAREN)) {
+        return nullptr;
+    }
 
-  this->nextToken();
-  expr->condition = this->parseExpression(Precedences.LOWEST);
+    this->nextToken();
+    expr->condition = this->parseExpression(Precedences.LOWEST);
 
-  if (!expectPeek(TokenType.RPAREN)) {
-    return nullptr;
-  }
+    if (!expectPeek(TokenType.RPAREN)) {
+        return nullptr;
+    }
 
-  if (!expectPeek(TokenType.LBRACE)) {
-    return nullptr;
-  }
-  expr->body = this->parseBlockStatement();
+    if (!expectPeek(TokenType.LBRACE)) {
+        return nullptr;
+    }
+    expr->body = this->parseBlockStatement();
 
-  return expr;
+    return expr;
 }
 
-
-void Parser::peekErrors(string t){
-  ostringstream ss;
-  ss << "Expected next token to be " << t << ", but got " 
-    << this->peekToken.type << " instead" << '\n'; 
-  this->errors.push_back(ss.str());
+void Parser::peekErrors(string t) {
+    ostringstream ss;
+    ss << "Expected next token to be " << t << ", but got " << this->peekToken.type << " instead"
+       << '\n';
+    this->errors.push_back(ss.str());
 }
-
 
 int Parser::peekPrecedence() {
-  int p;
-  try {
-    p = precedencesMap.at(this->peekToken.type);
-    return p;
-  }
-  catch (out_of_range&) {
-    return Precedences.LOWEST;
-  }
+    int p;
+    try {
+        p = precedencesMap.at(this->peekToken.type);
+        return p;
+    } catch (out_of_range&) {
+        return Precedences.LOWEST;
+    }
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "lexer.hpp"
-#include <vector>
 
+#include <vector>
 
 // Forward Declarations
 struct ArrayLiteral;
@@ -32,11 +32,10 @@ struct LetStatement;
 struct ReturnStatement;
 struct Statement;
 
-
 class Parser {
   public:
     Parser(std::string);
-    ~Parser() {this->errors.clear();};
+    ~Parser() { this->errors.clear(); };
 
     Token currentToken;
     Token peekToken;
@@ -47,6 +46,7 @@ class Parser {
     void nextToken();
     std::shared_ptr<Statement> parseStatement();
     void peekErrors(std::string);
+
   private:
     std::shared_ptr<Lexer> lexer;
 
@@ -89,80 +89,67 @@ class Parser {
     std::shared_ptr<ReturnStatement> parseReturnStatement();
 };
 
-
 // Prefix Functions
 enum prefix {
-  PREFIX_STD,
-  PREFIX_IDENT,
-  PREFIX_INT,
-  PREFIX_FLOAT,
-  PREFIX_STRING,
-  PREFIX_BOOL,
-  PREFIX_IF,
-  PREFIX_FUNCTION,
-  PREFIX_DO,
-  PREFIX_WHILE,
-  PREFIX_FOR,
-  PREFIX_INCREMENT,
-  PREFIX_DECREMENT,
-  PREFIX_GROUPED_EXPR,
-  PREFIX_ASSIGN,
-  PREFIX_ARRAY,
-  PREFIX_HASH,
+    PREFIX_STD,
+    PREFIX_IDENT,
+    PREFIX_INT,
+    PREFIX_FLOAT,
+    PREFIX_STRING,
+    PREFIX_BOOL,
+    PREFIX_IF,
+    PREFIX_FUNCTION,
+    PREFIX_DO,
+    PREFIX_WHILE,
+    PREFIX_FOR,
+    PREFIX_INCREMENT,
+    PREFIX_DECREMENT,
+    PREFIX_GROUPED_EXPR,
+    PREFIX_ASSIGN,
+    PREFIX_ARRAY,
+    PREFIX_HASH,
 };
-
 
 const std::unordered_map<std::string, int> prefixFunctions = {
-  {TokenType.IDENT, PREFIX_IDENT},
-  {TokenType.INT, PREFIX_INT},
-  {TokenType.FLOAT, PREFIX_FLOAT},
-  {TokenType._STRING, PREFIX_STRING},
-  {TokenType.BANG, PREFIX_STD},
-  {TokenType.MINUS, PREFIX_STD},
-  {TokenType._TRUE, PREFIX_BOOL},
-  {TokenType._FALSE, PREFIX_BOOL},
-  {TokenType.LPAREN, PREFIX_GROUPED_EXPR},
-  {TokenType.IF, PREFIX_IF},
-  {TokenType.FUNCTION, PREFIX_FUNCTION},
-  {TokenType.DO, PREFIX_DO},
-  {TokenType.WHILE, PREFIX_WHILE},
-  {TokenType.FOR, PREFIX_FOR},
-  {TokenType.PLUS_EQ, PREFIX_ASSIGN},
-  {TokenType.MINUS_EQ, PREFIX_ASSIGN},
-  {TokenType.MULT_EQ, PREFIX_ASSIGN},
-  {TokenType.DIV_EQ, PREFIX_ASSIGN},
-  {TokenType.LBRACKET, PREFIX_ARRAY},
-  {TokenType.LBRACE, PREFIX_HASH},
+    {TokenType.IDENT, PREFIX_IDENT},
+    {TokenType.INT, PREFIX_INT},
+    {TokenType.FLOAT, PREFIX_FLOAT},
+    {TokenType._STRING, PREFIX_STRING},
+    {TokenType.BANG, PREFIX_STD},
+    {TokenType.MINUS, PREFIX_STD},
+    {TokenType._TRUE, PREFIX_BOOL},
+    {TokenType._FALSE, PREFIX_BOOL},
+    {TokenType.LPAREN, PREFIX_GROUPED_EXPR},
+    {TokenType.IF, PREFIX_IF},
+    {TokenType.FUNCTION, PREFIX_FUNCTION},
+    {TokenType.DO, PREFIX_DO},
+    {TokenType.WHILE, PREFIX_WHILE},
+    {TokenType.FOR, PREFIX_FOR},
+    {TokenType.PLUS_EQ, PREFIX_ASSIGN},
+    {TokenType.MINUS_EQ, PREFIX_ASSIGN},
+    {TokenType.MULT_EQ, PREFIX_ASSIGN},
+    {TokenType.DIV_EQ, PREFIX_ASSIGN},
+    {TokenType.LBRACKET, PREFIX_ARRAY},
+    {TokenType.LBRACE, PREFIX_HASH},
 };
-
 
 // Infix Functions
 enum infix {
-  INFIX_STD,
-  INFIX_CALL,
-  INFIX_INDEX,
+    INFIX_STD,
+    INFIX_CALL,
+    INFIX_INDEX,
 };
-
 
 const std::unordered_map<std::string, int> infixFunctions = {
-  {TokenType.PLUS, INFIX_STD},
-  {TokenType.MINUS, INFIX_STD},
-  {TokenType.SLASH, INFIX_STD},
-  {TokenType.ASTERISK, INFIX_STD},
-  {TokenType.EQ, INFIX_STD},
-  {TokenType.NOT_EQ, INFIX_STD},
-  {TokenType.LT, INFIX_STD},
-  {TokenType.GT, INFIX_STD},
-  {TokenType.LPAREN, INFIX_CALL},
-  {TokenType.LBRACKET, INFIX_INDEX},
+    {TokenType.PLUS, INFIX_STD},       {TokenType.MINUS, INFIX_STD}, {TokenType.SLASH, INFIX_STD},
+    {TokenType.ASTERISK, INFIX_STD},   {TokenType.EQ, INFIX_STD},    {TokenType.NOT_EQ, INFIX_STD},
+    {TokenType.LT, INFIX_STD},         {TokenType.GT, INFIX_STD},    {TokenType.LPAREN, INFIX_CALL},
+    {TokenType.LBRACKET, INFIX_INDEX},
 };
 
-
-enum postfix {
-  POSTFIX
-};
+enum postfix { POSTFIX };
 
 const std::unordered_map<std::string, int> postfixFunctions = {
-  {TokenType.INCREMENT, POSTFIX},
-  {TokenType.DECREMENT, POSTFIX},
+    {TokenType.INCREMENT, POSTFIX},
+    {TokenType.DECREMENT, POSTFIX},
 };

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -1,42 +1,41 @@
 #include "object.hpp"
-#include <vector>
+
 #include <iostream>
+#include <vector>
 
 using namespace std;
 void printParserErrors(vector<string>);
 shared_ptr<Object> evalNode(shared_ptr<Node>, shared_ptr<Environment>);
 void setErrorGarbageCollector(shared_ptr<Environment>*);
 
-
 void start(string input, shared_ptr<Environment> env) {
-  unique_ptr<AST> ast (new AST(input));
-  ast->parseProgram();
+    unique_ptr<AST> ast(new AST(input));
+    ast->parseProgram();
 
-  if (ast->parser->errors.size() != 0) {
-    printParserErrors(ast->parser->errors);
-    return;
-  }
-
-  setErrorGarbageCollector(&env);
-
-  for (auto stmt : ast->Statements) {
-    shared_ptr<Object> evaluated = evalNode(stmt, env);
-    if (evaluated != nullptr) {
-      if (evaluated->type == ERROR_OBJ) {
-        shared_ptr<Error> result = static_pointer_cast<Error>(evaluated);
-        cout << result->message << '\n';
-        continue;
-      }
+    if (ast->parser->errors.size() != 0) {
+        printParserErrors(ast->parser->errors);
+        return;
     }
-  }
-  ast->Statements.clear();
+
+    setErrorGarbageCollector(&env);
+
+    for (auto stmt : ast->Statements) {
+        shared_ptr<Object> evaluated = evalNode(stmt, env);
+        if (evaluated != nullptr) {
+            if (evaluated->type == ERROR_OBJ) {
+                shared_ptr<Error> result = static_pointer_cast<Error>(evaluated);
+                cout << result->message << '\n';
+                continue;
+            }
+        }
+    }
+    ast->Statements.clear();
 }
 
-
 void printParserErrors(vector<string> errs) {
-  cout << "parser error:\n";
-  for (auto err : errs)
-    cout << '\t' << err << '\n';
+    cout << "parser error:\n";
+    for (auto err : errs)
+        cout << '\t' << err << '\n';
 }
 
 // Tokenizer Print
@@ -46,7 +45,7 @@ void printParserErrors(vector<string> errs) {
 //
 //   vector<string> tokenVector;
 //
-//   while (tok.type != TokenType._EOF) 
+//   while (tok.type != TokenType._EOF)
 //   {
 //       string curr = "{Type:" + tok.type + " Literal: " + tok.literal + '\n';
 //       tokenVector.push_back(curr);

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -3,119 +3,100 @@
 #include <string>
 #include <unordered_map>
 
-
 enum DATATYPE {
-  INT,
-  FLOAT,
-  BOOLEAN,
-  _STRING,
-  VOID,
+    INT,
+    FLOAT,
+    BOOLEAN,
+    _STRING,
+    VOID,
 };
 
-
 typedef struct Token {
-  std::string type;
-  std::string literal;
-}
-Token;
-
+    std::string type;
+    std::string literal;
+} Token;
 
 const struct Tokentype {
-  std::string ILLEGAL = {"ILLEGAL"};
-  std::string NEWLINE = {"NEWLINE"};
-  std::string _EOF = {"_EOF"};
+    std::string ILLEGAL = {"ILLEGAL"};
+    std::string NEWLINE = {"NEWLINE"};
+    std::string _EOF = {"_EOF"};
 
-  // Identifiers + Literals
-  std::string IDENT = {"IDENT"};
-  std::string DATATYPE = {"DATATYPE"};
+    // Identifiers + Literals
+    std::string IDENT = {"IDENT"};
+    std::string DATATYPE = {"DATATYPE"};
 
-  // Data Types
-  std::string BOOLEAN = {"BOOLEAN"};
-  std::string INT = {"INT"};
-  std::string FLOAT = {"FLOAT"};
-  std::string _STRING = {"_STRING"};
-  std::string VOID = {"VOID"};
+    // Data Types
+    std::string BOOLEAN = {"BOOLEAN"};
+    std::string INT = {"INT"};
+    std::string FLOAT = {"FLOAT"};
+    std::string _STRING = {"_STRING"};
+    std::string VOID = {"VOID"};
 
-  // Keywords
-  std::string LET = {"LET"};
-  std::string FUNCTION = {"FUNCTION"};
-  std::string _TRUE = {"TRUE"};
-  std::string _FALSE = {"FALSE"};
-  std::string IF = {"IF"};
-  std::string ELSE = {"ELSE"};
-  std::string ELSEIF = {"ELSEIF"};
-  std::string RETURN = {"RETURN"}; 
-  std::string DO = {"DO"};
-  std::string WHILE = {"WHILE"};
-  std::string FOR = {"FOR"};
-  std::string IN = {"IN"};
+    // Keywords
+    std::string LET = {"LET"};
+    std::string FUNCTION = {"FUNCTION"};
+    std::string _TRUE = {"TRUE"};
+    std::string _FALSE = {"FALSE"};
+    std::string IF = {"IF"};
+    std::string ELSE = {"ELSE"};
+    std::string ELSEIF = {"ELSEIF"};
+    std::string RETURN = {"RETURN"};
+    std::string DO = {"DO"};
+    std::string WHILE = {"WHILE"};
+    std::string FOR = {"FOR"};
+    std::string IN = {"IN"};
 
-  // Operators
-  std::string EQ = {"EQ"};
-  std::string NOT_EQ = {"NOT_EQ"};
-  std::string ASSIGN = {"ASSIGN"};
-  std::string PLUS = {"PLUS"};
-  std::string MINUS = {"MINUS"};
-  std::string ASTERISK = {"ASTERISK"};
-  std::string SLASH = {"SLASH"};
-  std::string INCREMENT = {"INCREMENT"};
-  std::string DECREMENT = {"DECREMENT"};
-  std::string ASSIGN_EQ = {"ASSIGN_EQ"};
-  std::string PLUS_EQ = {"ASSIGN_EQ"};
-  std::string MINUS_EQ = {"ASSIGN_EQ"};
-  std::string MULT_EQ = {"ASSIGN_EQ"};
-  std::string DIV_EQ = {"ASSIGN_EQ"};
+    // Operators
+    std::string EQ = {"EQ"};
+    std::string NOT_EQ = {"NOT_EQ"};
+    std::string ASSIGN = {"ASSIGN"};
+    std::string PLUS = {"PLUS"};
+    std::string MINUS = {"MINUS"};
+    std::string ASTERISK = {"ASTERISK"};
+    std::string SLASH = {"SLASH"};
+    std::string INCREMENT = {"INCREMENT"};
+    std::string DECREMENT = {"DECREMENT"};
+    std::string ASSIGN_EQ = {"ASSIGN_EQ"};
+    std::string PLUS_EQ = {"ASSIGN_EQ"};
+    std::string MINUS_EQ = {"ASSIGN_EQ"};
+    std::string MULT_EQ = {"ASSIGN_EQ"};
+    std::string DIV_EQ = {"ASSIGN_EQ"};
 
-  // Delimiters
-  std::string COMMA = {"COMMA"};
-  std::string PERIOD = {"PERIOD"};
-  std::string COLON = {"COLON"};
-  std::string SEMICOLON = {"SEMICOLON"};
-  std::string BANG = {"BANG"};
-  std::string LPAREN = {"LPAREN"};
-  std::string RPAREN = {"RPAREN"};
-  std::string LBRACE = {"LBRACE"};
-  std::string RBRACE = {"RBRACE"};
-  std::string LBRACKET = {"LBRACKET"};
-  std::string RBRACKET = {"RBRACKET"};
-  std::string LT = {"LT"};
-  std::string GT = {"GT"};
-  std::string APOSTROPHE = {"APOSTROPHE"};
-  std::string QUOTE = {"QUOTE"};
+    // Delimiters
+    std::string COMMA = {"COMMA"};
+    std::string PERIOD = {"PERIOD"};
+    std::string COLON = {"COLON"};
+    std::string SEMICOLON = {"SEMICOLON"};
+    std::string BANG = {"BANG"};
+    std::string LPAREN = {"LPAREN"};
+    std::string RPAREN = {"RPAREN"};
+    std::string LBRACE = {"LBRACE"};
+    std::string RBRACE = {"RBRACE"};
+    std::string LBRACKET = {"LBRACKET"};
+    std::string RBRACKET = {"RBRACKET"};
+    std::string LT = {"LT"};
+    std::string GT = {"GT"};
+    std::string APOSTROPHE = {"APOSTROPHE"};
+    std::string QUOTE = {"QUOTE"};
 
-  // Comments
-  std::string COMMENT = {"COMMENT"};
-  std::string BLOCK_COMMENT = {"BLOCK_COMMENT"};
-} TokenType{}; 
-
+    // Comments
+    std::string COMMENT = {"COMMENT"};
+    std::string BLOCK_COMMENT = {"BLOCK_COMMENT"};
+} TokenType{};
 
 const std::unordered_map<std::string, std::string> keywords = {
-  {"fn", TokenType.FUNCTION},
-  {"let", TokenType.LET},
-  {"true", TokenType._TRUE},
-  {"false", TokenType._FALSE},
-  {"if", TokenType.IF},
-  {"else", TokenType.ELSE},
-  {"else if", TokenType.ELSEIF},
-  {"return", TokenType.RETURN},
-  {"do", TokenType.DO},
-  {"while", TokenType.WHILE},
-  {"for", TokenType.FOR},
-  {"in", TokenType.IN},
-  {"==", TokenType.EQ},
-  {"!=", TokenType.NOT_EQ},
-  {"//", TokenType.COMMENT},
-  {"/*", TokenType.BLOCK_COMMENT},
-  {"++", TokenType.INCREMENT},
-  {"--", TokenType.DECREMENT},
-  {"+=", TokenType.PLUS_EQ},
-  {"-=", TokenType.MINUS_EQ},
-  {"*=", TokenType.MULT_EQ},
-  {"/=", TokenType.DIV_EQ},
-  {"int", TokenType.DATATYPE},
-  {"long", TokenType.DATATYPE},
-  {"float", TokenType.DATATYPE},
-  {"bool", TokenType.DATATYPE},
-  {"string", TokenType.DATATYPE},
-  {"void", TokenType.DATATYPE},
+    {"fn", TokenType.FUNCTION},     {"let", TokenType.LET},
+    {"true", TokenType._TRUE},      {"false", TokenType._FALSE},
+    {"if", TokenType.IF},           {"else", TokenType.ELSE},
+    {"else if", TokenType.ELSEIF},  {"return", TokenType.RETURN},
+    {"do", TokenType.DO},           {"while", TokenType.WHILE},
+    {"for", TokenType.FOR},         {"in", TokenType.IN},
+    {"==", TokenType.EQ},           {"!=", TokenType.NOT_EQ},
+    {"//", TokenType.COMMENT},      {"/*", TokenType.BLOCK_COMMENT},
+    {"++", TokenType.INCREMENT},    {"--", TokenType.DECREMENT},
+    {"+=", TokenType.PLUS_EQ},      {"-=", TokenType.MINUS_EQ},
+    {"*=", TokenType.MULT_EQ},      {"/=", TokenType.DIV_EQ},
+    {"int", TokenType.DATATYPE},    {"long", TokenType.DATATYPE},
+    {"float", TokenType.DATATYPE},  {"bool", TokenType.DATATYPE},
+    {"string", TokenType.DATATYPE}, {"void", TokenType.DATATYPE},
 };


### PR DESCRIPTION
used clang-format to clean things up, and used 4-space indents instead of 2.